### PR TITLE
faster decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.nyc_output
 /benchmark
 /.vscode
+/wasm/sixel.wasm
+/src/wasm.json

--- a/index.html
+++ b/index.html
@@ -51,7 +51,11 @@
   <br><br>
   <span id="stats"></span>
   <br><br>
+  Default decoder:<br>
   <canvas id="output" style="border: 1px solid black"></canvas>
+  <br><br>
+  L2 decoder (wasm):<br>
+  <canvas id="output_wasm" style="border: 1px solid black"></canvas>
   <br><br>
   Reencoded with img2sixel:<br>
   <canvas id="output2" style="border: 1px solid black"></canvas>
@@ -61,6 +65,39 @@
 
 let drawHandle = null;
 let imgS = null;
+let imgWasm = null;
+let wasmDecoder = null;
+sixel.WasmDecoderAsync().then(dec => wasmDecoder = dec);
+
+function decodeWasm(bytes) {
+  const start = new Date();
+  const dim = new sixel.DimensionDecoder().decode(bytes);
+  console.log('L2 attrs:', dim);
+  if (sixel.canUseWasm(dim.width, dim.height, 4096)) {
+    wasmDecoder.init(
+      dim.width,
+      dim.height,
+      sixel.toRGBA8888(...hexColorToRGB(document.getElementById('fillColor').value))  
+    );
+    wasmDecoder.decode(bytes);
+  }
+  drawImageL2(wasmDecoder.data32, wasmDecoder.width, wasmDecoder.height);
+  console.log('L2 conversion:', (new Date()) - start);
+}
+
+function drawImageL2(data, width, height) {
+  if (!height || !width) {
+    return;
+  }
+  const canvas = document.getElementById('output_wasm');
+  const ctx = canvas.getContext('2d');
+  // resize canvas to show full image
+  canvas.width = width;
+  canvas.height = height;
+  const target = new ImageData(width, height);
+  new Uint32Array(target.data.buffer).set(data);
+  ctx.putImageData(target, 0, 0);
+}
 
 /**
  * example how to get the img data
@@ -75,7 +112,8 @@ function drawImage(img) {
   canvas.width = img.width;
   canvas.height = img.height;
   // grab imagedata
-  const target = ctx.getImageData(0, 0, img.width, img.height);
+  // const target = ctx.getImageData(0, 0, img.width, img.height);
+  const target = new ImageData(img.width, img.height);
   img.toPixelData(
     // target metrics
     target.data, img.width, img.height,
@@ -90,21 +128,33 @@ function drawImage(img) {
   ctx.putImageData(target, 0, 0);
 
   // test encoding by re-encoding the output above
-  const reEncoded = sixel.image2sixel(target.data, img.width, img.height);
-  const six2 = new sixel.SixelDecoder();
-  six2.decodeString(reEncoded.slice(7, -2)); // strip off enclosing escape sequence
-  const canvas2 = document.getElementById('output2');
-  canvas2.width = six2.width;
-  canvas2.height = six2.height;
-  const ctx2 = canvas2.getContext('2d');
-  const target2 = ctx.getImageData(0, 0, six2.width, six2.height);
-  six2.toPixelData(target2.data, six2.width, six2.height);
-  ctx2.putImageData(target2, 0, 0);
+  //const reEncoded = sixel.image2sixel(target.data, img.width, img.height);
+  //const dim = new sixel.DimensionDecoder().decodeString(reEncoded.slice(7, -2));
+  //if (sixel.canUseWasm(dim.width, dim.height, 4096)) {
+  //  wasmDecoder.init(dim.width, dim.height, 0)  
+  //  wasmDecoder.decodeString(reEncoded.slice(7, -2));
+  //  const canvas2 = document.getElementById('output2');
+  //  canvas2.width = dim.width;
+  //  canvas2.height = dim.height;
+  //  const ctx2 = canvas2.getContext('2d');
+  //  const target2 = ctx.getImageData(0, 0, dim.width, dim.height);
+  //  new Uint32Array(target2.data.buffer).set(wasmDecoder.data32);
+  //  ctx2.putImageData(target2, 0, 0);
+  //} else {
+  //  const six2 = new sixel.SixelDecoder();
+  //  six2.decodeString(reEncoded.slice(7, -2)); // strip off enclosing escape sequence
+  //  const canvas2 = document.getElementById('output2');
+  //  canvas2.width = six2.width;
+  //  canvas2.height = six2.height;
+  //  const ctx2 = canvas2.getContext('2d');
+  //  const target2 = ctx.getImageData(0, 0, six2.width, six2.height);
+  //  six2.toPixelData(target2.data, six2.width, six2.height);
+  //  ctx2.putImageData(target2, 0, 0);
+  //}
 }
 
 function hexColorToRGB(color) {
   const value = parseInt(color.slice(1), 16);
-  console.log();
   return [
   (value >> 16) & 0xFF,
   (value >> 8) & 0xFF,
@@ -132,6 +182,7 @@ async function setImage(s) {
   } else {
     const response = await fetch('/testfiles/' + s);
     const bytes = new Uint8Array(await response.arrayBuffer());
+    decodeWasm(bytes);
     start = new Date();
     if (document.getElementById('slow').checked) {
       let localHandle = drawHandle = setInterval(() => drawImage(img), 100);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "webpack-cli && http-server",
     "prepublish": "npm run tsc",
     "coverage": "nyc --reporter=lcov --reporter=text --reporter=html npm test",
-    "benchmark": "xterm-benchmark $*"
+    "benchmark": "xterm-benchmark $*",
+    "build-wasm": "bash -c wasm/build.sh"
   },
   "keywords": [
     "sixel",
@@ -27,24 +28,22 @@
   "dependencies": {},
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@types/chai": "^4.2.14",
-    "@types/mocha": "^8.0.4",
-    "@types/node": "^12.12.37",
-    "canvas": "^2.6.1",
-    "chai": "^4.2.0",
+    "@types/mocha": "^8.2.2",
+    "@types/node": "^14.17.3",
+    "canvas": "^2.8.0",
     "http-server": "^0.12.3",
-    "mocha": "^8.2.1",
+    "mocha": "^9.0.1",
     "node-ansiparser": "^2.2.0",
     "nyc": "^15.1.0",
-    "open": "^7.3.0",
+    "open": "^8.2.1",
     "rgbquant": "^1.1.2",
     "source-map-support": "^0.5.19",
-    "ts-loader": "^8.0.11",
-    "ts-node": "^9.0.0",
+    "ts-loader": "^9.2.3",
+    "ts-node": "^10.0.0",
     "tslint": "^6.1.3",
-    "typescript": "^4.0.5",
-    "webpack": "^5.5.1",
-    "webpack-cli": "^4.2.0",
-    "xterm-benchmark": "^0.2.0"
+    "typescript": "^4.3.4",
+    "webpack": "^5.40.0",
+    "webpack-cli": "^4.7.2",
+    "xterm-benchmark": "^0.2.1"
   }
 }

--- a/src/Colors.test.ts
+++ b/src/Colors.test.ts
@@ -3,106 +3,117 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { fromRGBA8888, toRGBA8888, BIG_ENDIAN, red, green, blue, alpha, normalizeHLS, normalizeRGB, nearestColorIndex } from './Colors';
+import * as colors from './Colors';
 
 describe('Colors', () => {
   describe('toRGBA888', () => {
     it('conversions', () => {
-      assert.equal(toRGBA8888(0, 0, 0, 0), 0);
-      assert.equal(toRGBA8888(0, 0, 0, 255), BIG_ENDIAN ? 0x000000FF : 0xFF000000);
-      assert.equal(toRGBA8888(0, 0, 255, 0), BIG_ENDIAN ? 0x0000FF00 : 0x00FF0000);
-      assert.equal(toRGBA8888(0, 255, 0, 0), BIG_ENDIAN ? 0x00FF0000 : 0x0000FF00);
-      assert.equal(toRGBA8888(255, 0, 0, 0), BIG_ENDIAN ? 0xFF000000 : 0x000000FF);
+      assert.strictEqual(toRGBA8888(0, 0, 0, 0), 0);
+      assert.strictEqual(toRGBA8888(0, 0, 0, 255), BIG_ENDIAN ? 0x000000FF : 0xFF000000);
+      assert.strictEqual(toRGBA8888(0, 0, 255, 0), BIG_ENDIAN ? 0x0000FF00 : 0x00FF0000);
+      assert.strictEqual(toRGBA8888(0, 255, 0, 0), BIG_ENDIAN ? 0x00FF0000 : 0x0000FF00);
+      assert.strictEqual(toRGBA8888(255, 0, 0, 0), BIG_ENDIAN ? 0xFF000000 : 0x000000FF);
     });
     it('alpha defaults to 255', () => {
-      assert.equal(toRGBA8888(0, 0, 0), toRGBA8888(0, 0, 0, 255));
-      assert.equal(toRGBA8888(0, 0, 255), toRGBA8888(0, 0, 255, 255));
-      assert.equal(toRGBA8888(0, 255, 0), toRGBA8888(0, 255, 0, 255));
-      assert.equal(toRGBA8888(255, 0, 0), toRGBA8888(255, 0, 0, 255));
-      assert.equal(toRGBA8888(0, 255, 255), toRGBA8888(0, 255, 255, 255));
-      assert.equal(toRGBA8888(255, 0, 255), toRGBA8888(255, 0, 255, 255));
-      assert.equal(toRGBA8888(255, 255, 0), toRGBA8888(255, 255, 0, 255));
-      assert.equal(toRGBA8888(255, 255, 255), toRGBA8888(255, 255, 255, 255));
+      assert.strictEqual(toRGBA8888(0, 0, 0), toRGBA8888(0, 0, 0, 255));
+      assert.strictEqual(toRGBA8888(0, 0, 255), toRGBA8888(0, 0, 255, 255));
+      assert.strictEqual(toRGBA8888(0, 255, 0), toRGBA8888(0, 255, 0, 255));
+      assert.strictEqual(toRGBA8888(255, 0, 0), toRGBA8888(255, 0, 0, 255));
+      assert.strictEqual(toRGBA8888(0, 255, 255), toRGBA8888(0, 255, 255, 255));
+      assert.strictEqual(toRGBA8888(255, 0, 255), toRGBA8888(255, 0, 255, 255));
+      assert.strictEqual(toRGBA8888(255, 255, 0), toRGBA8888(255, 255, 0, 255));
+      assert.strictEqual(toRGBA8888(255, 255, 255), toRGBA8888(255, 255, 255, 255));
     });
     it('should only return unsigned', () => {
       // test only for r and a here (g/b dont add to significant bit)
       for (let r = 0; r <= 0xFF; ++r) {
         for (let a = 0; a <= 0xFF; ++a) {
           const color = toRGBA8888(r, 0, 0, a);
-          assert.equal(color >= 0, true);
+          assert.strictEqual(color >= 0, true);
         }
       }
     });
     it('handled signed channel values', () => {
-      assert.equal(toRGBA8888(-8, -50, -100, -127), toRGBA8888(-8 >>> 0, -50 >>> 0, -100 >>> 0, -127 >>> 0));
+      assert.strictEqual(toRGBA8888(-8, -50, -100, -127), toRGBA8888(-8 >>> 0, -50 >>> 0, -100 >>> 0, -127 >>> 0));
     });
     it('strip channel values to 8 bit (not clamping)', () => {
-      assert.equal(toRGBA8888(0x1234, 0x5678, 0xabcd, 0xef11), BIG_ENDIAN ? 0x3478cd11 : 0x11cd7834);
+      assert.strictEqual(toRGBA8888(0x1234, 0x5678, 0xabcd, 0xef11), BIG_ENDIAN ? 0x3478cd11 : 0x11cd7834);
     });
   });
   describe('fromRGBA8888', () => {
     it('conversions', () => {
-      assert.deepEqual(fromRGBA8888(0), [0, 0, 0, 0]);
-      assert.deepEqual(fromRGBA8888(0x000000FF), BIG_ENDIAN ? [0, 0, 0, 255] : [255, 0, 0, 0]);
-      assert.deepEqual(fromRGBA8888(0x0000FF00), BIG_ENDIAN ? [0, 0, 255, 0] : [0, 255, 0, 0]);
-      assert.deepEqual(fromRGBA8888(0x00FF0000), BIG_ENDIAN ? [0, 255, 0, 0] : [0, 0, 255, 0]);
-      assert.deepEqual(fromRGBA8888(0xFF000000), BIG_ENDIAN ? [255, 0, 0, 0] : [0, 0, 0, 255]);
+      assert.deepStrictEqual(fromRGBA8888(0), [0, 0, 0, 0]);
+      assert.deepStrictEqual(fromRGBA8888(0x000000FF), BIG_ENDIAN ? [0, 0, 0, 255] : [255, 0, 0, 0]);
+      assert.deepStrictEqual(fromRGBA8888(0x0000FF00), BIG_ENDIAN ? [0, 0, 255, 0] : [0, 255, 0, 0]);
+      assert.deepStrictEqual(fromRGBA8888(0x00FF0000), BIG_ENDIAN ? [0, 255, 0, 0] : [0, 0, 255, 0]);
+      assert.deepStrictEqual(fromRGBA8888(0xFF000000), BIG_ENDIAN ? [255, 0, 0, 0] : [0, 0, 0, 255]);
     });
     it('should only create unsigned channel values', () => {
-      assert.deepEqual(fromRGBA8888(-1), [255, 255, 255, 255]);
+      assert.deepStrictEqual(fromRGBA8888(-1), [255, 255, 255, 255]);
       // 2 complement: -0xedcba988 ==> 0x12345678 (newDigit = 15 - digit; result + 1)
-      assert.deepEqual(fromRGBA8888(-0xedcba988), BIG_ENDIAN ? [0x12, 0x34, 0x56, 0x78] : [0x78, 0x56, 0x34, 0x12]);
+      assert.deepStrictEqual(fromRGBA8888(-0xedcba988), BIG_ENDIAN ? [0x12, 0x34, 0x56, 0x78] : [0x78, 0x56, 0x34, 0x12]);
     });
     it('strip values to 32bit', () => {
-      assert.deepEqual(fromRGBA8888(0x1234567890), BIG_ENDIAN ? [0x12, 0x34, 0x56, 0x78] : [0x90, 0x78, 0x56, 0x34]);
+      assert.deepStrictEqual(fromRGBA8888(0x1234567890), BIG_ENDIAN ? [0x12, 0x34, 0x56, 0x78] : [0x90, 0x78, 0x56, 0x34]);
     });
   });
   describe('channels', () => {
     it('red', () => {
-      assert.deepEqual(red(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x12);
+      assert.strictEqual(red(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x12);
     });
     it('green', () => {
-      assert.deepEqual(green(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x34);
+      assert.strictEqual(green(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x34);
     });
     it('blue', () => {
-      assert.deepEqual(blue(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x56);
+      assert.strictEqual(blue(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x56);
     });
     it('green', () => {
-      assert.deepEqual(alpha(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x78);
+      assert.strictEqual(alpha(toRGBA8888(0x12, 0x34, 0x56, 0x78)), 0x78);
     });
   });
   it('RGB/HLS VT340 normalization', () => {
     // values taken from https://vt100.net/docs/vt3xx-gp/chapter2.html#S2.4
-    assert.equal(normalizeHLS(0, 0, 0), normalizeRGB(0, 0, 0));
-    assert.equal(normalizeHLS(0, 50, 60), normalizeRGB(20, 20, 80));
-    assert.equal(normalizeHLS(120, 46, 72), normalizeRGB(80, 13, 13) - 2);              // mismatch R: 2
-    assert.equal(normalizeHLS(240, 50, 60), normalizeRGB(20, 80, 20));
-    assert.equal(normalizeHLS(60, 50, 60), normalizeRGB(80, 20, 80));
-    assert.equal(normalizeHLS(300, 50, 60), normalizeRGB(20, 80, 80));
-    assert.equal(normalizeHLS(180, 50, 60), normalizeRGB(80, 80, 20));
-    assert.equal(normalizeHLS(0, 53, 0), normalizeRGB(53, 53, 53));
-    assert.equal(normalizeHLS(0, 26, 0), normalizeRGB(26, 26, 26));
-    assert.equal(normalizeHLS(0, 46, 29), normalizeRGB(33, 33, 60) - 0x020101);         // mismatch B: 2 G: 1 R: 1
-    assert.equal(normalizeHLS(120, 43, 39), normalizeRGB(60, 26, 26) + 0x010100 - 0x1); // mismatch B: -1 G: -1 R: 1
-    assert.equal(normalizeHLS(240, 46, 29), normalizeRGB(33, 60, 33) - 0x010201);       // mismatch B: 1 G: 2 R: 1
-    // assert.equal(normalizeHLS(60, 46, 29), normalizeRGB(60, 33, 60));
-    // assert.equal(normalizeHLS(300, 46, 29), normalizeRGB(33, 60, 60));
-    // assert.equal(normalizeHLS(180, 46, 29), normalizeRGB(60, 60, 33));
-    assert.equal(normalizeHLS(0, 80, 0), normalizeRGB(80, 80, 80));
+    assert.strictEqual(normalizeHLS(0, 0, 0), normalizeRGB(0, 0, 0));
+    assert.strictEqual(normalizeHLS(0, 50, 60), normalizeRGB(20, 20, 80));
+    assert.strictEqual(normalizeHLS(120, 46, 72), normalizeRGB(80, 13, 13) - 2);              // mismatch R: 2
+    assert.strictEqual(normalizeHLS(240, 50, 60), normalizeRGB(20, 80, 20));
+    assert.strictEqual(normalizeHLS(60, 50, 60), normalizeRGB(80, 20, 80));
+    assert.strictEqual(normalizeHLS(300, 50, 60), normalizeRGB(20, 80, 80));
+    assert.strictEqual(normalizeHLS(180, 50, 60), normalizeRGB(80, 80, 20));
+    assert.strictEqual(normalizeHLS(0, 53, 0), normalizeRGB(53, 53, 53));
+    assert.strictEqual(normalizeHLS(0, 26, 0), normalizeRGB(26, 26, 26));
+    assert.strictEqual(normalizeHLS(0, 46, 29), normalizeRGB(33, 33, 60) - 0x020101);         // mismatch B: 2 G: 1 R: 1
+    assert.strictEqual(normalizeHLS(120, 43, 39), normalizeRGB(60, 26, 26) + 0x010100 - 0x1); // mismatch B: -1 G: -1 R: 1
+    assert.strictEqual(normalizeHLS(240, 46, 29), normalizeRGB(33, 60, 33) - 0x010201);       // mismatch B: 1 G: 2 R: 1
+    assert.strictEqual(normalizeHLS(0, 80, 0), normalizeRGB(80, 80, 80));
 
     // basic HLS tests
-    assert.equal(normalizeHLS(0, 50, 100), toRGBA8888(0, 0, 255));
-    assert.equal(normalizeHLS(120, 50, 100), toRGBA8888(255, 0, 0));
-    assert.equal(normalizeHLS(240, 50, 100), toRGBA8888(0, 255, 0));
-    assert.equal(normalizeHLS(180, 50, 100), toRGBA8888(255, 255, 0));
-    assert.equal(normalizeHLS(300, 50, 100), toRGBA8888(0, 255, 255));
-    assert.equal(normalizeHLS(60, 50, 100), toRGBA8888(255, 0, 255));
+    assert.strictEqual(normalizeHLS(0, 50, 100), toRGBA8888(0, 0, 255));
+    assert.strictEqual(normalizeHLS(120, 50, 100), toRGBA8888(255, 0, 0));
+    assert.strictEqual(normalizeHLS(240, 50, 100), toRGBA8888(0, 255, 0));
+    assert.strictEqual(normalizeHLS(180, 50, 100), toRGBA8888(255, 255, 0));
+    assert.strictEqual(normalizeHLS(300, 50, 100), toRGBA8888(0, 255, 255));
+    assert.strictEqual(normalizeHLS(60, 50, 100), toRGBA8888(255, 0, 255));
   });
   it('nearestColorIndex (ED)', () => {
     const p: [number, number, number][] = [[0, 0, 0], [50, 50, 0], [100, 50, 50], [100, 100, 100], [150, 100, 50]];
-    assert.equal(nearestColorIndex(toRGBA8888(1, 2, 3), p), 0);
-    assert.equal(nearestColorIndex(toRGBA8888(100, 100, 100), p), 3);
-    assert.equal(nearestColorIndex(toRGBA8888(170, 100, 50), p), 4);
+    assert.strictEqual(nearestColorIndex(toRGBA8888(1, 2, 3), p), 0);
+    assert.strictEqual(nearestColorIndex(toRGBA8888(100, 100, 100), p), 3);
+    assert.strictEqual(nearestColorIndex(toRGBA8888(170, 100, 50), p), 4);
+  });
+  it('BE fake tests', () => {
+    const endianess = BIG_ENDIAN;
+    (colors as any).BIG_ENDIAN = true;
+    colors.red(0x11223344);
+    assert.strictEqual(colors.red(0x11223344), 0x11);
+    assert.strictEqual(colors.green(0x11223344), 0x22);
+    assert.strictEqual(colors.blue(0x11223344), 0x33);
+    assert.strictEqual(colors.alpha(0x11223344), 0x44);
+    assert.deepStrictEqual(colors.fromRGBA8888(0x11223344), [0x11, 0x22, 0x33, 0x44]);
+    assert.strictEqual(colors.toRGBA8888(0x11, 0x22, 0x33, 0x44), 0x11223344);
+    assert.strictEqual(colors.normalizeHLS(0, 50, 60), colors.normalizeRGB(20, 20, 80));
+    (colors as any).BIG_ENDIAN = endianess;
   });
 });

--- a/src/Colors.ts
+++ b/src/Colors.ts
@@ -38,7 +38,7 @@ export function toRGBA8888(r: number, g: number, b: number, a: number = 255): RG
 
 
 /**
- * Convert native color to [r, g, b].
+ * Convert native color to [r, g, b, a].
  */
 export function fromRGBA8888(color: RGBA8888): [number, number, number, number] {
   return (BIG_ENDIAN)

--- a/src/DimensionDecoder.test.ts
+++ b/src/DimensionDecoder.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2021 Joerg Breitbart.
+ * @license MIT
+ */
+import * as assert from 'assert';
+import { DimensionDecoder } from './DimensionDecoder';
+
+function s2b(s: string): Uint8Array {
+  const result = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; ++i) {
+    result[i] = s.charCodeAt(i);
+  }
+  return result;
+}
+
+function grab2<T extends (string | Uint8Array)>(data: T): T[] {
+  const result: T[] = [];
+  let p = 0;
+  while (p < data.length) {
+    result.push((data as any).slice(p, p + 2));
+    p += 2;
+  }
+  return result;
+}
+
+
+describe('DimensionDecoder', () => {
+  it('decode - l2', () => {
+    const dimDec = new DimensionDecoder();
+    assert.deepStrictEqual(
+      dimDec.decode(s2b('"1;2;640;480--')),
+      { numerator: 1, denominator: 2, width: 640, height: 480, index: 12, level: 2 }
+    );
+    dimDec.reset();
+    assert.deepStrictEqual(
+      dimDec.decode(s2b('        "1;2;640;480#0~~')),
+      { numerator: 1, denominator: 2, width: 640, height: 480, index: 20, level: 2 }
+    );
+    dimDec.reset();
+    for (const [i, chunk] of grab2(s2b('"1;2;640;480--')).entries()) {
+      const dim = dimDec.decode(chunk);
+      if (dim) {
+        assert.deepStrictEqual(dim, { numerator: 1, denominator: 2, width: 640, height: 480, index: 0, level: 2 });
+        assert.strictEqual(i, 6);
+        break;
+      }
+    }
+    dimDec.reset();
+    for (const [i, chunk] of grab2(s2b('        "1;2;640;480#0~~')).entries()) {
+      const dim = dimDec.decode(chunk);
+      if (dim) {
+        assert.deepStrictEqual(dim, { numerator: 1, denominator: 2, width: 640, height: 480, index: 0, level: 2 });
+        assert.strictEqual(i, 10);
+        break;
+      }
+    }
+  });
+  it('decode - l1', () => {
+    const dimDec = new DimensionDecoder();
+    assert.deepStrictEqual(
+      dimDec.decode(s2b('$--#0~~~')),
+      { numerator: -1, denominator: -1, width: -1, height: -1, index: 0, level: 1 }
+    );
+    dimDec.reset();
+    assert.deepStrictEqual(
+      dimDec.decode(s2b('        ~~~~')),
+      { numerator: -1, denominator: -1, width: -1, height: -1, index: 8, level: 1 }
+    );
+  });
+  it('decodeString - l2', () => {
+    const dimDec = new DimensionDecoder();
+    assert.deepStrictEqual(
+      dimDec.decodeString('"1;2;640;480--'),
+      { numerator: 1, denominator: 2, width: 640, height: 480, index: 12, level: 2 }
+    );
+    dimDec.reset();
+    assert.deepStrictEqual(
+      dimDec.decodeString('        "1;2;640;480#0~~'),
+      { numerator: 1, denominator: 2, width: 640, height: 480, index: 20, level: 2 }
+    );
+    dimDec.reset();
+    for (const [i, chunk] of grab2('"1;2;640;480--').entries()) {
+      const dim = dimDec.decodeString(chunk);
+      if (dim) {
+        assert.deepStrictEqual(dim, { numerator: 1, denominator: 2, width: 640, height: 480, index: 0, level: 2 });
+        assert.strictEqual(i, 6);
+        break;
+      }
+    }
+    dimDec.reset();
+    for (const [i, chunk] of grab2('        "1;2;640;480#0~~').entries()) {
+      const dim = dimDec.decodeString(chunk);
+      if (dim) {
+        assert.deepStrictEqual(dim, { numerator: 1, denominator: 2, width: 640, height: 480, index: 0, level: 2 });
+        assert.strictEqual(i, 10);
+        break;
+      }
+    }
+  });
+  it('decodeString - l1', () => {
+    const dimDec = new DimensionDecoder();
+    assert.deepStrictEqual(
+      dimDec.decodeString('$--#0~~~'),
+      { numerator: -1, denominator: -1, width: -1, height: -1, index: 0, level: 1 }
+    );
+    dimDec.reset();
+    assert.deepStrictEqual(
+      dimDec.decodeString('        ~~~~'),
+      { numerator: -1, denominator: -1, width: -1, height: -1, index: 8, level: 1 }
+    );
+  });
+  it('coverage', () => {
+    const dimDec = new DimensionDecoder();
+    assert.deepStrictEqual(
+      dimDec.decodeString('"1;1~~~'),
+      { numerator: -1, denominator: -1, width: -1, height: -1, index: 4, level: 1 }
+    );
+  });
+});

--- a/src/DimensionDecoder.ts
+++ b/src/DimensionDecoder.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2021 Joerg Breitbart.
+ * @license MIT
+ */
+
+import { Params } from './Params';
+import { UintTypedArray, SixelState, ISixelDimensions } from './Types';
+
+
+/**
+ * Helper decoder to get image dimensions from raster attributes.
+ * 
+ * Useful to synchronously extract image dimensions,
+ * while the expensive data decoding can be offloaded.
+ * 
+ * Meant to be used in conjunction with a level 2 decoder as follows:
+ * - feed early chunks to DimensionDecoder until it returns a `ISixelDimensions`
+ * - level 2 result: use `width` and `height` to create a SixelDecoderL2 instance
+ *   and resume async decoding at `result.index` of the last chunk in the new decoder instance
+ * - level 1 result: no valid raster attributes could be derived, image can only be decoded
+ *   synchronously by SixelDecoder with real band handling (again feed from `result.index`)
+ * 
+ * After calling `reset` the decoder instance can be reused with a new SIXEL data stream.
+ */
+export class DimensionDecoder {
+  private _state = SixelState.DATA;
+  private _params = new Params();
+  private _buffer = new Uint8Array(64);
+
+  public decodeString(data: string, start: number = 0, end: number = data.length): ISixelDimensions | undefined {
+    let p = start;
+    while (p < end) {
+      const length = Math.min(end - p, 64);
+      let j = p;
+      for (let i = 0; i < length; ++i, ++j) {
+        this._buffer[i] = data.charCodeAt(j);
+      }
+      const dim = this.decode(this._buffer, 0, length);
+      if (dim) {
+        dim.index += p;
+        return dim;
+      }
+      p += length;
+    }
+  }
+
+  public decode(data: UintTypedArray, start: number = 0, end: number = data.length): ISixelDimensions | undefined {
+    for (let i = start; i < end; ++i) {
+      const code = data[i];
+      if (this._state === SixelState.DATA) {
+        if ((code > 62 && code < 127) || code === 33 || code === 35 || code === 36 || code === 45) {
+          return { numerator: -1, denominator: -1, width: -1, height: -1, index: i, level: 1 };
+        } else if (code === 34) {
+          this._state = SixelState.ATTR;
+        }
+      } else if (this._state === SixelState.ATTR) {
+        if (code > 46 && code < 58) {
+          this._params.addDigit(code - 48);
+        } else if (code === 59) {
+          this._params.addParam();
+        } else {
+          if (this._params.length === 4) {
+            return {
+              numerator: this._params.params[0],
+              denominator: this._params.params[1],
+              width: this._params.params[2],
+              height: this._params.params[3],
+              index: i,
+              level: 2
+            };
+          }
+          return { numerator: -1, denominator: -1, width: -1, height: -1, index: i, level: 1 };
+        }
+      }
+    }
+  }
+
+  public reset(): void {
+    this._params.reset();
+    this._state = SixelState.DATA;
+  }
+}

--- a/src/Params.test.ts
+++ b/src/Params.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 Joerg Breitbart.
+ * @license MIT
+ */
+import * as assert from 'assert';
+import { Params } from './Params';
+
+describe('Params', () => {
+  it('should not overflow', () => {
+    const p = new Params();
+    assert.strictEqual(p.length, 1);
+    assert.strictEqual(p.params[0], 0);
+    p.addDigit(1);
+    p.addDigit(2);
+    p.addParam();
+    p.addDigit(3);
+    p.addDigit(4);
+    p.addParam();
+    p.addDigit(5);
+    p.addDigit(6);
+    p.addParam();
+    p.addDigit(7);
+    p.addDigit(8);
+    p.addParam();
+    p.addDigit(9);
+    p.addDigit(9);
+    p.addParam();
+    p.addDigit(1);
+    p.addDigit(1);
+    p.addParam();
+    assert.strictEqual(p.length, 6);
+    assert.deepStrictEqual(p.params, new Uint32Array([12, 34, 56, 78, 99, 0]));
+  });
+});

--- a/src/Params.ts
+++ b/src/Params.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2021 Joerg Breitbart.
+ * @license MIT
+ */
+
+
+/**
+ * Params storage.
+ * Used during parsing to hold up to 6 params of a SIXEL command.
+ */
+export class Params {
+  public length = 1;
+  public params = new Uint32Array(6);
+  public reset(): void {
+    this.params[0] = 0;
+    this.length = 1;
+  }
+  public addParam(): void {
+    if (this.length < 6) {
+      this.params[this.length++] = 0;
+    }
+  }
+  public addDigit(v: number): void {
+    if (this.length < 6) {
+      this.params[this.length - 1] = this.params[this.length - 1] * 10 + v;
+    }
+  }
+}

--- a/src/SixelDecoder.test.ts
+++ b/src/SixelDecoder.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { SixelDecoder } from './SixelDecoder';
 import { toRGBA8888, normalizeRGB, normalizeHLS } from './Colors';
 
@@ -14,14 +14,14 @@ describe('SixelDecoder', () => {
   });
   describe('empty data', () => {
     it('width/height are 0', () => {
-      assert.equal(dec.width, 0);
-      assert.equal(dec.height, 0);
+      assert.strictEqual(dec.width, 0);
+      assert.strictEqual(dec.height, 0);
     });
     it('toPixelData does not throw or alter target', () => {
       const target = new Uint8ClampedArray(256 * 4);
       target.fill(10);
       assert.doesNotThrow(() => dec.toPixelData(target, 16, 16));
-      assert.deepEqual(target, (new Uint8ClampedArray(256 * 4)).fill(10));
+      assert.deepStrictEqual(target, (new Uint8ClampedArray(256 * 4)).fill(10));
     });
   });
   describe('decode parser', () => {
@@ -34,26 +34,26 @@ describe('SixelDecoder', () => {
           if (~except.indexOf(i)) continue;
           input[0] = i;
           dec.decode(input, 0, 1);
-          assert.equal((dec as any)._currentState, 0);  // 0 == DATA
+          assert.strictEqual((dec as any)._currentState, 0);  // 0 == DATA
         }
       });
       it('DATA -> COMPRESSION', () => {
         const input = new Uint8Array(10);
         input[0] = 33;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 1);    // 1 == COMPRESSION
+        assert.strictEqual((dec as any)._currentState, 1);    // 1 == COMPRESSION
       });
       it('DATA -> ATTR', () => {
         const input = new Uint8Array(10);
         input[0] = 34;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 2);    // 2 == ATTR
+        assert.strictEqual((dec as any)._currentState, 2);    // 2 == ATTR
       });
       it('DATA -> COLOR', () => {
         const input = new Uint8Array(10);
         input[0] = 35;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 3);    // 3 == COLOR
+        assert.strictEqual((dec as any)._currentState, 3);    // 3 == COLOR
       });
       it('COMPRESSION -> COMPRESSION', () => {
         (dec as any)._currentState = 1;
@@ -63,7 +63,7 @@ describe('SixelDecoder', () => {
           if (191 <= i && i <= 254) continue; // high numbers result from & 0x7F conversion
           input[0] = i;
           dec.decode(input, 0, 1);
-          assert.equal((dec as any)._currentState, 1);
+          assert.strictEqual((dec as any)._currentState, 1);
         }
       });
       it('COMPRESSION -> DATA', () => {
@@ -72,7 +72,7 @@ describe('SixelDecoder', () => {
         for (let i = 63; i < 127; ++i) {
           input[0] = i;
           dec.decode(input, 0, 1);
-          assert.equal((dec as any)._currentState, 0);
+          assert.strictEqual((dec as any)._currentState, 0);
           (dec as any)._currentState = 1;
         }
       });
@@ -87,7 +87,7 @@ describe('SixelDecoder', () => {
           if (191 <= i && i <= 254) continue; // high numbers result from & 0x7F conversion
           input[0] = i;
           dec.decode(input, 0, 1);
-          assert.equal((dec as any)._currentState, 2);
+          assert.strictEqual((dec as any)._currentState, 2);
           (dec as any)._currentState = 2;
         }
       });
@@ -97,31 +97,31 @@ describe('SixelDecoder', () => {
         for (let i = 63; i < 127; ++i) {
           input[0] = i;
           dec.decode(input, 0, 1);
-          assert.equal((dec as any)._currentState, 0);
+          assert.strictEqual((dec as any)._currentState, 0);
           (dec as any)._currentState = 2;
         }
         (dec as any)._currentState = 2;
         input[0] = 36;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 0);
+        assert.strictEqual((dec as any)._currentState, 0);
         (dec as any)._currentState = 2;
         input[0] = 45;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 0);
+        assert.strictEqual((dec as any)._currentState, 0);
       });
       it('ATTR -> COMPRESSION', () => {
         (dec as any)._currentState = 2;
         const input = new Uint8Array(10);
         input[0] = 33;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 1);    // 1 == COMPRESSION
+        assert.strictEqual((dec as any)._currentState, 1);    // 1 == COMPRESSION
       });
       it('ATTR -> COLOR', () => {
         (dec as any)._currentState = 2;
         const input = new Uint8Array(10);
         input[0] = 35;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 3);    // 3 == COLOR
+        assert.strictEqual((dec as any)._currentState, 3);    // 3 == COLOR
       });
       it('COLOR -> COLOR', () => {
         // excluded chars leading to other states
@@ -134,7 +134,7 @@ describe('SixelDecoder', () => {
           if (191 <= i && i <= 254) continue; // high numbers result from & 0x7F conversion
           input[0] = i;
           dec.decode(input, 0, 1);
-          assert.equal((dec as any)._currentState, 3);
+          assert.strictEqual((dec as any)._currentState, 3);
           (dec as any)._currentState = 3;
         }
       });
@@ -144,159 +144,159 @@ describe('SixelDecoder', () => {
         for (let i = 63; i < 127; ++i) {
           input[0] = i;
           dec.decode(input, 0, 1);
-          assert.equal((dec as any)._currentState, 0);
+          assert.strictEqual((dec as any)._currentState, 0);
           (dec as any)._currentState = 3;
         }
         (dec as any)._currentState = 3;
         input[0] = 36;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 0);
+        assert.strictEqual((dec as any)._currentState, 0);
         (dec as any)._currentState = 3;
         input[0] = 45;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 0);
+        assert.strictEqual((dec as any)._currentState, 0);
       });
       it('COLOR -> COMPRESSION', () => {
         (dec as any)._currentState = 3;
         const input = new Uint8Array(10);
         input[0] = 33;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 1);    // 1 == COMPRESSION
+        assert.strictEqual((dec as any)._currentState, 1);    // 1 == COMPRESSION
       });
       it('COLOR -> ATTR', () => {
         (dec as any)._currentState = 3;
         const input = new Uint8Array(10);
         input[0] = 34;
         dec.decode(input, 0, 1);
-        assert.equal((dec as any)._currentState, 2);    // 2 == ATTR
+        assert.strictEqual((dec as any)._currentState, 2);    // 2 == ATTR
       });
     });
     describe('actions', () => {
       it('DRAW', () => {
         const data = '?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
         dec.decodeString(data);
-        assert.equal(dec.bands.length, 1);
-        assert.equal(dec.bands[0].width, 64);
+        assert.strictEqual(dec.bands.length, 1);
+        assert.strictEqual(dec.bands[0].width, 64);
         const color = dec.palette[0];
         for (let c = 0; c < data.length; ++c) {
           const offset = c * 6;
           const code = data.charCodeAt(c) - 63;
           for (let p = 0; p < 6; ++p) {
-            assert.equal(dec.bands[0].data[offset + p], code & (1 << p) ? color : 0);
+            assert.strictEqual(dec.bands[0].data[offset + p], code & (1 << p) ? color : 0);
           }
         }
       });
       it('STORE_PARAM', () => {
         dec.decodeString('#1');
-        assert.equal((dec as any)._params.params[0], 1);
+        assert.strictEqual((dec as any)._params.params[0], 1);
         dec.decodeString('2');
-        assert.equal((dec as any)._params.params[0], 12);
+        assert.strictEqual((dec as any)._params.params[0], 12);
         dec.decodeString('3');
-        assert.equal((dec as any)._params.params[0], 123);
+        assert.strictEqual((dec as any)._params.params[0], 123);
         dec.decodeString('4');
-        assert.equal((dec as any)._params.params[0], 1234);
+        assert.strictEqual((dec as any)._params.params[0], 1234);
       });
       it('SHIFT_PARAM', () => {
         // shift with ; in ATTR and COLOR
         dec.decodeString('#1');
-        assert.equal((dec as any)._params.length, 1);
-        assert.equal((dec as any)._params.params[0], 1);
+        assert.strictEqual((dec as any)._params.length, 1);
+        assert.strictEqual((dec as any)._params.params[0], 1);
         dec.decodeString(';');
-        assert.equal((dec as any)._params.length, 2);
-        assert.equal((dec as any)._params.params[0], 1);
-        assert.equal((dec as any)._params.params[1], 0);
+        assert.strictEqual((dec as any)._params.length, 2);
+        assert.strictEqual((dec as any)._params.params[0], 1);
+        assert.strictEqual((dec as any)._params.params[1], 0);
         dec.decodeString(';12345');
-        assert.equal((dec as any)._params.length, 3);
-        assert.equal((dec as any)._params.params[0], 1);
-        assert.equal((dec as any)._params.params[1], 0);
-        assert.equal((dec as any)._params.params[2], 12345);
+        assert.strictEqual((dec as any)._params.length, 3);
+        assert.strictEqual((dec as any)._params.params[0], 1);
+        assert.strictEqual((dec as any)._params.params[1], 0);
+        assert.strictEqual((dec as any)._params.params[2], 12345);
         // shift with ! in COMPRESSION
         dec.decodeString('!100');
-        assert.equal((dec as any)._params.length, 1);
-        assert.equal((dec as any)._params.params[0], 100);
+        assert.strictEqual((dec as any)._params.length, 1);
+        assert.strictEqual((dec as any)._params.params[0], 100);
         dec.decodeString('!200!300');
-        assert.equal((dec as any)._params.length, 3);
-        assert.equal((dec as any)._params.params[0], 100);
-        assert.equal((dec as any)._params.params[1], 200);
-        assert.equal((dec as any)._params.params[2], 300);
+        assert.strictEqual((dec as any)._params.length, 3);
+        assert.strictEqual((dec as any)._params.params[0], 100);
+        assert.strictEqual((dec as any)._params.params[1], 200);
+        assert.strictEqual((dec as any)._params.params[2], 300);
       });
       describe('APPLY_PARAM', () => {
         it('ATTR', () => {
           // w'o DRAW
-          assert.equal(dec.rasterWidth, 0);
-          assert.equal(dec.rasterHeight, 0);
-          assert.equal(dec.rasterRatioNumerator, 0);
-          assert.equal(dec.rasterRatioDenominator, 0);
+          assert.strictEqual(dec.rasterWidth, 0);
+          assert.strictEqual(dec.rasterHeight, 0);
+          assert.strictEqual(dec.rasterRatioNumerator, 0);
+          assert.strictEqual(dec.rasterRatioDenominator, 0);
           dec.decodeString('"1;2;3;4$');
-          assert.equal(dec.rasterWidth, 3);
-          assert.equal(dec.rasterHeight, 4);
-          assert.equal(dec.rasterRatioNumerator, 1);
-          assert.equal(dec.rasterRatioDenominator, 2);
-          assert.equal(dec.bands[0].width, 0);
+          assert.strictEqual(dec.rasterWidth, 3);
+          assert.strictEqual(dec.rasterHeight, 4);
+          assert.strictEqual(dec.rasterRatioNumerator, 1);
+          assert.strictEqual(dec.rasterRatioDenominator, 2);
+          assert.strictEqual(dec.bands[0].width, 0);
           // with DRAW
           dec.decodeString('"5;6;7;8@');
-          assert.equal(dec.rasterWidth, 7);
-          assert.equal(dec.rasterHeight, 8);
-          assert.equal(dec.rasterRatioNumerator, 5);
-          assert.equal(dec.rasterRatioDenominator, 6);
-          assert.equal(dec.bands[0].width, 1);
+          assert.strictEqual(dec.rasterWidth, 7);
+          assert.strictEqual(dec.rasterHeight, 8);
+          assert.strictEqual(dec.rasterRatioNumerator, 5);
+          assert.strictEqual(dec.rasterRatioDenominator, 6);
+          assert.strictEqual(dec.bands[0].width, 1);
           // should not reapply raster once drawn
           dec.decodeString('"9;10;11;12@');
-          assert.equal(dec.rasterWidth, 7);
-          assert.equal(dec.rasterHeight, 8);
-          assert.equal(dec.rasterRatioNumerator, 5);
-          assert.equal(dec.rasterRatioDenominator, 6);
-          assert.equal(dec.bands[0].width, 2);
+          assert.strictEqual(dec.rasterWidth, 7);
+          assert.strictEqual(dec.rasterHeight, 8);
+          assert.strictEqual(dec.rasterRatioNumerator, 5);
+          assert.strictEqual(dec.rasterRatioDenominator, 6);
+          assert.strictEqual(dec.bands[0].width, 2);
         });
         it('COLOR', () => {
           dec.palette = [toRGBA8888(1, 2, 3), toRGBA8888(4, 5, 6)];
           dec.paletteLimit = 2;
           // slot select
           dec.decodeString('#0$');
-          assert.equal((dec as any)._currentColor, toRGBA8888(1, 2, 3));
+          assert.strictEqual((dec as any)._currentColor, toRGBA8888(1, 2, 3));
           dec.decodeString('#1$');
-          assert.equal((dec as any)._currentColor, toRGBA8888(4, 5, 6));
+          assert.strictEqual((dec as any)._currentColor, toRGBA8888(4, 5, 6));
           dec.decodeString('#2$');
-          assert.equal((dec as any)._currentColor, toRGBA8888(1, 2, 3));
+          assert.strictEqual((dec as any)._currentColor, toRGBA8888(1, 2, 3));
           // color definitions
           // RGB
           dec.decodeString('#1;2;25;50;75$');
-          assert.equal(dec.palette[1], normalizeRGB(25, 50, 75));
-          assert.equal((dec as any)._currentColor, normalizeRGB(25, 50, 75));
+          assert.strictEqual(dec.palette[1], normalizeRGB(25, 50, 75));
+          assert.strictEqual((dec as any)._currentColor, normalizeRGB(25, 50, 75));
           // HLS
           dec.decodeString('#1;1;25;50;75$');
-          assert.equal(dec.palette[1], normalizeHLS(25, 50, 75));
-          assert.equal((dec as any)._currentColor, normalizeHLS(25, 50, 75));
+          assert.strictEqual(dec.palette[1], normalizeHLS(25, 50, 75));
+          assert.strictEqual((dec as any)._currentColor, normalizeHLS(25, 50, 75));
           // illegal: Pu = 0
           dec.decodeString('#0;0;25;50;75$');
-          assert.equal(dec.palette[1], normalizeHLS(25, 50, 75)); // did not change
-          assert.equal((dec as any)._currentColor, toRGBA8888(1, 2, 3)); // slot 0 selected, still old color
+          assert.strictEqual(dec.palette[1], normalizeHLS(25, 50, 75)); // did not change
+          assert.strictEqual((dec as any)._currentColor, toRGBA8888(1, 2, 3)); // slot 0 selected, still old color
           // broken command
           dec.decodeString('#1;4;500;1000;1234$');
-          assert.equal(dec.palette[1], normalizeHLS(25, 50, 75)); // no color change
-          assert.equal((dec as any)._currentColor, toRGBA8888(1, 2, 3)); // select slot not executed
+          assert.strictEqual(dec.palette[1], normalizeHLS(25, 50, 75)); // no color change
+          assert.strictEqual((dec as any)._currentColor, toRGBA8888(1, 2, 3)); // select slot not executed
         });
       });
       it('REPEATED_DRAW', () => {
         let rep = -1;
         dec.bands[0].put = (code, color, repeat) => { rep = repeat; };
         dec.decodeString('!12345@');
-        assert.equal(rep, 12345);
+        assert.strictEqual(rep, 12345);
         dec.decodeString('!0@');
-        assert.equal(rep, 1);
+        assert.strictEqual(rep, 1);
         dec.decodeString('!0!1!2!3!500@');
-        assert.equal(rep, 1 + 1 + 2 + 3 + 500);
+        assert.strictEqual(rep, 1 + 1 + 2 + 3 + 500);
       });
       it('CR', () => {
         dec.decodeString('!0!1!2!3!500@');
-        assert.equal(dec.bands[0].cursor, 1 + 1 + 2 + 3 + 500);
+        assert.strictEqual(dec.bands[0].cursor, 1 + 1 + 2 + 3 + 500);
         dec.decodeString('$');
-        assert.equal(dec.bands[0].cursor, 0);
+        assert.strictEqual(dec.bands[0].cursor, 0);
       });
       it('LF', () => {
-        assert.equal(dec.bands.length, 1);
+        assert.strictEqual(dec.bands.length, 1);
         dec.decodeString('---');
-        assert.equal(dec.bands.length, 4);
+        assert.strictEqual(dec.bands.length, 4);
       });
     });
   });

--- a/src/SixelDecoder.ts
+++ b/src/SixelDecoder.ts
@@ -3,8 +3,9 @@
  * @license MIT
  */
 
-import { RGBA8888, UintTypedArray } from './Types';
+import { RGBA8888, SixelAction, SixelState, UintTypedArray } from './Types';
 import { PALETTE_VT340_COLOR, DEFAULT_BACKGROUND, normalizeHLS, normalizeRGB } from './Colors';
+import { Params } from './Params';
 
 // lookup table for for index offsets of SIXEL codes
 const OFFSETS: number[][] = [];
@@ -35,7 +36,6 @@ class SixelBand {
    * Get current memory usage of the band.
    */
   public get memUsage(): number {
-    // FIXME: calc other stuff too?
     return this.data.length * 4;
   }
 
@@ -149,24 +149,6 @@ class SixelBand {
  * * need to draw here (inspect next state)
  */
 
-const enum SixelState {
-  DATA = 0,
-  COMPRESSION = 1,
-  ATTR = 2,
-  COLOR = 3
-}
-
-const enum SixelAction {
-  IGNORE = 0,
-  DRAW = 1,
-  CR = 2,
-  LF = 3,
-  REPEATED_DRAW = 4,
-  STORE_PARAM = 5,
-  SHIFT_PARAM = 6,
-  APPLY_PARAM = 7
-}
-
 function r(low: number, high: number): number[] {
   let c = high - low;
   const arr = new Array(c);
@@ -232,25 +214,6 @@ const SIXEL_TABLE = (() => {
   table.add(45, SixelState.COLOR, SixelAction.APPLY_PARAM, SixelState.DATA);
   return table;
 })();
-
-/**
- * Params storage.
- * Used during parsing to hold up to 32 params of a SIXEL command.
- */
-class Params {
-  public length = 1;
-  public params = new Uint32Array(32);
-  public reset(): void {
-    this.params[0] = 0;
-    this.length = 1;
-  }
-  public addParam(): void {
-    this.params[this.length++] = 0;
-  }
-  public addDigit(v: number): void {
-    this.params[this.length - 1] = this.params[this.length - 1] * 10 + v;
-  }
-}
 
 
 /**
@@ -484,6 +447,9 @@ export class SixelDecoder {
           // read ahead: if next state is DATA we already got a char to handle here
           if ((transition & 15) === SixelState.DATA && code > 62 && code < 127) {
             band.put(code - 63, color, 1);
+          } else if (code === 45) {
+            band = new SixelBand(this.width || 4);
+            this.bands.push(band);
           }
           break;
         case SixelAction.REPEATED_DRAW:
@@ -580,5 +546,10 @@ export class SixelDecoder {
       }
     }
     return target;
+  }
+
+  public get data32(): Uint32Array {
+    // FIXME: to be implemented
+    return new Uint32Array();
   }
 }

--- a/src/SixelDecoderL2.ts
+++ b/src/SixelDecoderL2.ts
@@ -1,0 +1,522 @@
+/**
+ * Copyright (c) 2019 Joerg Breitbart.
+ * @license MIT
+ */
+
+import { ISixelDecoder, RGBA8888, UintTypedArray } from './Types';
+import { PALETTE_VT340_COLOR, DEFAULT_BACKGROUND, normalizeHLS, normalizeRGB } from './Colors';
+
+
+const enum SixelState {
+  DATA = 0,
+  COMPRESSION = 1,
+  ATTR = 2,
+  COLOR = 3
+}
+
+
+/**
+ * Params storage.
+ * Used during parsing to hold up to 32 params of a SIXEL command.
+ * 
+ * FIXME: needs bound check!
+ */
+class Params {
+  public length = 1;
+  public params = new Uint32Array(32);
+  public reset(): void {
+    this.params[0] = 0;
+    this.length = 1;
+  }
+  public addParam(): void {
+    this.params[this.length++] = 0;
+  }
+  public addDigit(v: number): void {
+    this.params[this.length - 1] = this.params[this.length - 1] * 10 + v;
+  }
+}
+
+const EMPTY_PIXELS = new Uint32Array(0);
+const STATIC_CANVAS = new Uint32Array(1024*1024);
+
+
+/**
+ * SixelDecoderL2 - highly optimized SIXEL level 2 decoder.
+ * 
+ * Other than the general purpose `SixelDecoder` this decoder
+ * works only with SIXEL level 2 under the following assumptions:
+ * - SIXEL data must start with a valid raster attribute command
+ * - attributes were prefetched with `DimensionDecoder`
+ * - preallocated image buffer at ctor level, pixels beyond width/height are ignored
+ * - pixels are written at their final position, no rotation anymore
+ * 
+ * These simplifications show roughly 50% speed gain of SIXEL decoding.
+ * Furthermore the separation of the dimension extraction allows this
+ * decoder to run in a worker, while the terminal still can prepare
+ * the needed buffer space synchronously.
+ * 
+ * 
+ * 
+ * FIXME: rewrite below ---------------------------------------<<<<<<<<<<<<<<<<<<<<<<<
+ * SixelDecoder class.
+ *
+ * 
+ * 
+ * The class provides image attributes `width` and `height`.
+ * With `toPixelData` the pixel data can be copied to an typed array
+ * for further processing.
+ *
+ * `write` and `writeString` decode SIXEL data streamlined, therefore it
+ * is possible to grab partial images during transmission.
+ *
+ * Note that the class is meant to run behind an escape sequence parser,
+ * thus the data should only be the real data part of the sequence and not
+ * contain the sequence introducer and finalizer.
+ *
+ * Further note that this class does not deal with custom pixel sizes/ratios or
+ * grid sizes. It always assumes a 1:1 ratio and returns the pixel data without
+ * any grid size notion. If you need strict pixel ratio and grid size handling
+ * for the final output, eval the DCS SIXEL macro parameter (P1) and horizontal
+ * grid size (P3) afterwards in conjunction with the raster attributes held by
+ * `rasterRatioNumerator` and `rasterRatioDenominator`.
+ */
+export class SixelDecoderL2 {
+  public rasterRatioNumerator = 0;
+  public rasterRatioDenominator = 0;
+  public rasterWidth = 0;
+  public rasterHeight = 0;
+  private _data32: Uint32Array;
+
+  private _maxY = 0;
+  private _cursor = 0;
+  private _OFFSETS: number[][] = [];
+  private _hasRaster = false;
+  private _offset = 0;
+
+  private _initial = SixelState.DATA;
+  private _state = this._initial;
+  private _params = new Params();
+  private _color = this.palette[0];
+
+  /**
+   * Create a new decoder instance.
+   *
+   * `fillColor` sets the color of pixels that are not encoded by SIXEL data (background).
+   * Depending on the second parameter of the DCS SIXEL sequence (background select - P2)
+   * this should either be set to the terminal default background color (P2 = 0 or 2),
+   * or to 0 to leave these pixels untouched (P2 = 1). Default is black.
+   *
+   * `palette` should contain the default palette of the terminal as `RGBA8888[]`.
+   * The library provides 3 default palettes - 16 color VT340, 16 greyscale VT340 and
+   * 256 ANSI colors (default is 16 color VT340). SIXEL data is likely to alter color entries of the palette,
+   * thus make sure to clone your palette if the changes should not be terminal wide (default).
+   *
+   * `paletteLimit` sets a hard limit of allowed color entries. Any color definitions beyond
+   * this limit will be mapped back into the allowed palette size (modulo). Historically
+   * terminals had certain hardware limits to represent colors at once (VT340 up to 16 colors registers).
+   * Nowadays with most outputs being RGB capable this is a lesser concern,
+   * alter this value only if you need strict old device compatibility. By default
+   * `paletteLimit` is set to a rather high value (65536) to allow more fine grained colors.
+   * The SIXEL spec (DEC STD 070) demands at least 256 registers.
+   *
+   * @param fillColor background fill color
+   * @param palette default palette to start with
+   * @param paletteLimit Hard limit for palette slots (default 65536). Values higher than the limit get mapped back.
+   */
+  constructor(
+    public fillColor: RGBA8888 = DEFAULT_BACKGROUND,
+    public palette: RGBA8888[] = Object.assign([], PALETTE_VT340_COLOR),
+    public paletteLimit: number = 65536,
+    public buffer?: Uint32Array) {
+    this._data32 = STATIC_CANVAS; // EMPTY_PIXELS;
+  }
+
+  /**
+   * Get current memory usage of the image data in bytes.
+   * Can be used to restrict image handling if memory is limited.
+   *
+   * Note: This only accounts the image pixel data storage, the real value
+   * will be slightly higher due to some additional JS object overhead.
+   */
+  public get memUsage(): number {
+    return this._data32.length * 4;
+  }
+
+  public get data(): Uint8ClampedArray {
+    return new Uint8ClampedArray(this._data32.buffer);
+  }
+
+  /**
+   * Put SIXEL `code` at current cursor position `repeat` times.
+   * 
+   * FIXME: Do x bound check, but no y check (shall be done in decode).
+   */
+  private _put(code: number, color: RGBA8888, repeat: number) {
+    // FIXME: x and y bound checks!!!
+    if (code && this._hasRaster) {
+      const t = this._OFFSETS[code];
+      const l = t.length;
+      let offset = this._offset + this._cursor;
+      for (let i = 0; i < l; ++i) {
+        const pos = offset + t[i];
+        this._data32[pos] = color;
+        for (let r = 1; r < repeat; ++r) {
+          this._data32[pos + r] = color;
+        }
+      }
+    }
+    this._cursor += repeat;
+  }
+
+  private _putS(code: number, color: RGBA8888) {
+    // FIXME: x and y bound checks!!!
+    // if (!code) return;
+    const t = this._OFFSETS[code];
+    const l = t.length;
+    const offset = this._offset + this._cursor;
+    for (let i = 0; i < l; ++i) {
+      this._data32[offset + t[i]] = color;
+    }
+  }
+
+  private jumper(code: number): void {
+    switch (code) {
+      case 33:
+        this._state = SixelState.COMPRESSION;
+        break;
+      case 35:
+        this._state = SixelState.COLOR;
+        break;
+      case 36:
+        this._cursor = 0;
+        break;
+      case 45:
+        this._maxY += 6;
+        this._offset = this._maxY * this.rasterWidth;
+        this._cursor = 0;
+        break;
+      case 34:
+        this._state = SixelState.ATTR;
+        break;
+    }
+  }
+
+  public decode(data: UintTypedArray, start: number = 0, end: number = data.length): void {
+    for (let i = start; i < end; ++i) {
+      let code = data[i] & 0x7F;
+      switch (this._state) {
+        case SixelState.DATA:
+          if (code > 62) {
+            this._putS(code - 63, this._color);
+            this._cursor++;
+          } else this.jumper(code);
+          break;
+        case SixelState.COMPRESSION:
+          if (code > 47 && code < 58) {
+            this._params.addDigit(code - 48);
+          } else if (code > 62) {
+            this._put(code - 63, this._color, this._params.params[0]);
+            this._params.reset();
+            this._state = SixelState.DATA;
+          } else switch (code) {
+            case 33:
+              this._params.addParam();
+              break;
+            case 35:
+              this._params.reset();
+              this._state = SixelState.COLOR;
+              break;
+            case 36:
+              this._params.reset();
+              this._cursor = 0;
+              break;
+            case 45:
+              this._params.reset();
+              this._maxY += 6;
+              this._offset = this._maxY * this.rasterWidth;
+              this._cursor = 0;
+              break;
+            case 34:
+              this._params.reset();
+              this._state = SixelState.ATTR;
+              break;
+          }
+          break;
+        case SixelState.COLOR:
+          if (code > 47 && code < 58) {
+            this._params.addDigit(code - 48);
+          } else if (code === 59) {
+            this._params.addParam();
+          } else if (code > 62 || code === 33 || code === 35 || code === 36 || code === 45) {
+            if (this._params.length === 1) {
+              // color select with modulo palette length
+              this._color = this.palette[this._params.params[0] % this.paletteLimit] >>> 0;
+            } else if (this._params.length === 5) {
+              // range test for all params
+              // cancel whole command if not passing all
+              if (this._params.params[1] < 3
+                && this._params.params[1] === 1 ? this._params.params[2] <= 360 : this._params.params[2] <= 100
+                && this._params.params[2] <= 100
+                && this._params.params[3] <= 100) {
+                switch (this._params.params[1]) {
+                  case 2:  // RGB
+                    this.palette[this._params.params[0] % this.paletteLimit] = this._color = normalizeRGB(
+                      this._params.params[2], this._params.params[3], this._params.params[4]);
+                    break;
+                  case 1:  // HLS
+                    this.palette[this._params.params[0] % this.paletteLimit] = this._color = normalizeHLS(
+                      this._params.params[2], this._params.params[3], this._params.params[4]);
+                    break;
+                  case 0:  // illegal, only apply color switch
+                    this._color = this.palette[this._params.params[0] % this.paletteLimit] >>> 0;
+                }
+              }
+            }
+            this._params.reset();
+            if (code > 62) {
+              this._put(code - 63, this._color, 1);
+              this._state = SixelState.DATA;
+            } else this.jumper(code);
+          }
+          break;
+        case SixelState.ATTR:
+          if (code > 47 && code < 58) {
+            this._params.addDigit(code - 48);
+          } else if (code === 59) {
+            this._params.addParam();
+          } else {
+            // FIXME: to be removed
+            if (!this._cursor && !this._maxY) {
+              if (this._params.length === 4) {
+                // Note: we only use width and height later on
+                this.rasterRatioNumerator = this._params.params[0];
+                this.rasterRatioDenominator = this._params.params[1];
+                this.rasterWidth = this._params.params[2];
+                this.rasterHeight = this._params.params[3];
+                // TODO: recycle buffer? -- ctor option for external allocator
+                // FIXME: move to ctor...
+                //this._data32 = new Uint32Array(this.rasterWidth * this.rasterHeight);
+                //this._data32.fill(this.fillColor);
+                for (let i = 0; i < 64; ++i) {
+                  const indices: number[] = [];
+                  if (i & 1) indices.push(0 * this.rasterWidth);
+                  if (i & 2) indices.push(1 * this.rasterWidth);
+                  if (i & 4) indices.push(2 * this.rasterWidth);
+                  if (i & 8) indices.push(3 * this.rasterWidth);
+                  if (i & 16) indices.push(4 * this.rasterWidth);
+                  if (i & 32) indices.push(5 * this.rasterWidth);
+                  this._OFFSETS.push(indices);
+                }
+                this._hasRaster = true;
+              }
+            }
+            this._params.reset();
+            if (code > 62) {
+              this._put(code - 63, this._color, 1);
+              this._state = SixelState.DATA;
+            } else this.jumper(code);
+          }
+      }
+    }
+  }
+
+  /**
+   * Decodes SIXEL bytes and updates the image data. This is done as a stream,
+   * therefore it is possible to grab partially transmitted images.
+   * `data` can be any array like type with single byte values per index position.
+   *
+   * Note: This method is only meant for the data part of a SIXEL DCS sequence,
+   * to properly handle full sequences consider running `SixelDecoder` behind
+   * an escape sequence parser.
+   */
+  public decode_old(data: UintTypedArray, start: number = 0, end: number = data.length): void {
+    for (let i = start; i < end; ++i) {
+      const code = data[i] & 0x7F;
+      if (this._state === SixelState.DATA) {
+        if (code > 62 && code < 127) this._put(code - 63, this._color, 1);
+        else switch (code) {
+          case 33:
+            this._state = SixelState.COMPRESSION;
+            break;
+          case 35:
+            this._state = SixelState.COLOR;
+            break;
+          case 36:
+            this._cursor = 0;
+            break;
+          case 45:
+            this._maxY += 6;
+            this._offset = this._maxY * this.rasterWidth;
+            this._cursor = 0;
+            break;
+          case 34:
+            this._state = SixelState.ATTR;
+            break;
+        }
+        // if (code > 62 && code < 127) {
+        //   this._put(code - 63, this._color, 1);
+        // } else if (code === 33) {
+        //   this._state = SixelState.COMPRESSION;
+        // } else if (code === 34) {
+        //   this._state = SixelState.ATTR;
+        // } else if (code === 35) {
+        //   this._state = SixelState.COLOR;
+        // } else if (code === 36) {
+        //   this._cursor = 0;
+        // } else if (code === 45) {
+        //   this._maxY += 6;
+        //   this._offset = this._maxY * this.rasterWidth;
+        //   this._cursor = 0;
+        // }
+      } else if (this._state === SixelState.COMPRESSION) {
+        if (code > 47 && code < 58) {
+          this._params.addDigit(code - 48);
+        } else if (code > 62 && code < 127) {
+          this._put(code - 63, this._color, this._params.params[0]);
+          this._params.reset();
+          this._state = SixelState.DATA;
+        } else if (code === 33) {
+          this._params.addParam();
+        } // FIXME: CR LF COLOR COMPRESSION handling missing
+      } else if (this._state === SixelState.COLOR) {
+        if (code > 47 && code < 58) {
+          this._params.addDigit(code - 48);
+        } else if (code === 59) {
+          this._params.addParam();
+        } else if ((code > 62 && code < 127) || code === 33 || code === 35 || code === 36 || code === 45) {
+
+          if (this._params.length === 1) {
+            // color select with modulo palette length
+            this._color = this.palette[this._params.params[0] % this.paletteLimit] >>> 0;
+          } else if (this._params.length === 5) {
+            // range test for all params
+            // cancel whole command if not passing all
+            if (this._params.params[1] < 3
+              && this._params.params[1] === 1 ? this._params.params[2] <= 360 : this._params.params[2] <= 100
+              && this._params.params[2] <= 100
+              && this._params.params[3] <= 100) {
+              switch (this._params.params[1]) {
+                case 2:
+                  // RGB
+                  this.palette[this._params.params[0] % this.paletteLimit] = this._color = normalizeRGB(
+                    this._params.params[2], this._params.params[3], this._params.params[4]);
+                  break;
+                case 1:
+                  // HLS
+                  this.palette[this._params.params[0] % this.paletteLimit] = this._color = normalizeHLS(
+                    this._params.params[2], this._params.params[3], this._params.params[4]);
+                  break;
+                case 0:
+                  // illegal, only apply color switch
+                  this._color = this.palette[this._params.params[0] % this.paletteLimit] >>> 0;
+              }
+            }
+          }
+          this._params.reset();
+          if (code > 62 && code < 127) {
+            this._put(code - 63, this._color, 1);
+            this._state = SixelState.DATA;
+          } else if (code === 33) {
+            this._state = SixelState.COMPRESSION;
+          } else if (code === 34) {
+            this._state = SixelState.ATTR;
+          } else if (code === 35) {
+            this._state = SixelState.COLOR;
+          } else if (code === 36) {
+            this._cursor = 0;
+          } else if (code === 45) {
+            this._maxY += 6;
+            this._offset = this._maxY * this.rasterWidth;
+            this._cursor = 0;
+          }
+        }
+      } else {
+        if (code > 47 && code < 58) {
+          this._params.addDigit(code - 48);
+        } else if (code === 59) {
+          this._params.addParam();
+        } else {
+          if (!this._cursor && !this._maxY) {
+            if (this._params.length === 4) {
+              // Note: we only use width and height later on
+              this.rasterRatioNumerator = this._params.params[0];
+              this.rasterRatioDenominator = this._params.params[1];
+              this.rasterWidth = this._params.params[2];
+              this.rasterHeight = this._params.params[3];
+              // TODO: recycle buffer? -- ctor option for external allocator
+              // FIXME: move to ctor...
+              this._data32 = new Uint32Array(this.rasterWidth * this.rasterHeight);
+              this._data32.fill(this.fillColor);
+              for (let i = 0; i < 64; ++i) {
+                const indices: number[] = [];
+                if (i & 1) indices.push(0 * this.rasterWidth);
+                if (i & 2) indices.push(1 * this.rasterWidth);
+                if (i & 4) indices.push(2 * this.rasterWidth);
+                if (i & 8) indices.push(3 * this.rasterWidth);
+                if (i & 16) indices.push(4 * this.rasterWidth);
+                if (i & 32) indices.push(5 * this.rasterWidth);
+                this._OFFSETS.push(indices);
+              }
+              this._hasRaster = true;
+            }
+          }
+          this._params.reset();
+          if (code > 62 && code < 127) {
+            this._put(code - 63, this._color, 1);
+            this._state = SixelState.DATA;
+          } else if (code === 33) {
+            this._state = SixelState.COMPRESSION;
+          } else if (code === 34) {
+            this._state = SixelState.ATTR;
+          } else if (code === 35) {
+            this._state = SixelState.COLOR;
+          } else if (code === 36) {
+            this._cursor = 0;
+          } else if (code === 45) {
+            this._maxY += 6;
+            this._offset = this._maxY * this.rasterWidth;
+            this._cursor = 0;
+          }
+        }
+      }
+    }
+  }
+
+  // FIXME: to be removed
+  public toPixelData(
+    target: Uint8ClampedArray, width: number, height: number,
+    dx: number = 0, dy: number = 0,
+    sx: number = 0, sy: number = 0, swidth: number = this.width, sheight: number = this.height,
+    fillColor: RGBA8888 = this.fillColor): Uint8ClampedArray {
+    new Uint32Array(target.buffer).set(this._data32);
+    return target;
+  }
+  private _buffer: Uint8Array;
+  public decodeString(data: string, start: number = 0, end: number = data.length): void {
+    if (!this._buffer || this._buffer.length < end - start) {
+      this._buffer = new Uint8Array(end - start);
+    }
+    let j = 0;
+    for (let i = start; i < end; ++i) {
+      this._buffer[j++] = data.charCodeAt(i);
+    }
+    this.decode(this._buffer, 0, j);
+  }
+  public get width(): number {
+    return this.rasterWidth;
+  }
+  public get height(): number {
+    return this.rasterHeight;
+  }
+  public get realWidth(): number {
+    return this.rasterWidth;
+  }
+  public get realHeight(): number {
+    return this.rasterHeight;
+  }
+
+  public pixelPtr(): Uint32Array {
+    return this._data32.subarray(0, this.width * this.height);
+  }
+}
+

--- a/src/SixelDecoderNew.ts
+++ b/src/SixelDecoderNew.ts
@@ -1,0 +1,64 @@
+import { DimensionDecoder } from './DimensionDecoder';
+import { ISixelDecoder, RGBA8888, UintTypedArray, ISixelDimensions } from './Types';
+import { WasmDecoder, canUseWasm } from './WasmDecoder';
+import { SixelDecoder as DefaultDecoder } from './SixelDecoder';
+
+
+interface ISixelDecoderOptions {
+  wasmEnabled?: boolean;
+  fillColor?: RGBA8888;
+  palette?: Uint32Array;
+  paletteLimit?: number; // FIXME: bootstrap from palette.length
+}
+
+
+export const SixelDecoderStreamAsync = function(opts: ISixelDecoderOptions): Promise<SixelDecoderStream> {
+  if (true) {
+    return new Promise(res => new SixelDecoderStream({}));
+  }
+  return Promise.resolve(new SixelDecoderStream(opts));
+} as any as { new (opts: ISixelDecoderOptions): Promise<SixelDecoderStream> };
+
+
+export class SixelDecoderStream implements ISixelDecoder {
+  private _impl: ISixelDecoder;
+  private _dimDec = new DimensionDecoder();
+  private _dim: ISixelDimensions | undefined;
+  constructor(public opts: ISixelDecoderOptions) {
+
+  }
+
+  public reset(): void {
+
+  }
+
+  public get width(): number {
+    return 0;
+  }
+
+  public get height(): number {
+    return 0;
+  }
+
+  public get palette(): Uint32Array {
+    return new Uint32Array();
+  }
+
+  public decode(data: UintTypedArray, start?: number, end?: number): void {
+    if (this._impl) {
+      this._impl.decode(data, end);
+    } else {
+      if (!(this._dim = this._dimDec.decode(data, start, end))) {
+        return;
+      }
+      //this._impl = canUseWasm(this._dim.width, this._dim.height, 123)
+      //  ? new WasmDecoder(this._dim.width, this._dim.height, 0)
+      //  : new DefaultDecoder(0) as any as ISixelDecoder;
+      //this._impl.decode(data, this._dim.index, end);
+    }
+  }
+
+  public get data32(): Uint32Array {
+    return this._impl.data32;
+  }
+}

--- a/src/SixelEncoder.test.ts
+++ b/src/SixelEncoder.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { introducer, FINALIZER, sixelEncode } from './SixelEncoder';
 import { SixelDecoder } from './SixelDecoder';
 import { normalizeRGB, toRGBA8888 } from './Colors';
@@ -17,29 +17,29 @@ describe('encoding', () => {
      * - we only support P2
      * - no 8 bit DCS support, only 7 bit notation
      */
-    assert.equal(introducer(), '\x1bP0;0;q');
-    assert.equal(introducer(0), '\x1bP0;0;q');
-    assert.equal(introducer(1), '\x1bP0;1;q');
-    assert.equal(introducer(2), '\x1bP0;2;q');
+    assert.strictEqual(introducer(), '\x1bP0;0;q');
+    assert.strictEqual(introducer(0), '\x1bP0;0;q');
+    assert.strictEqual(introducer(1), '\x1bP0;1;q');
+    assert.strictEqual(introducer(2), '\x1bP0;2;q');
   });
   it('FINALIZER 7bit ST', () => {
-    assert.equal(FINALIZER, '\x1b\\');
+    assert.strictEqual(FINALIZER, '\x1b\\');
   });
   describe('sixelEncode', () => {
     it('empty data, width/height of 0', () => {
       let sixels = '';
       assert.doesNotThrow(() => { sixels = sixelEncode(new Uint8Array(0), 1, 1, [0]); });
-      assert.equal(sixels, '');
+      assert.strictEqual(sixels, '');
       assert.doesNotThrow(() => { sixels = sixelEncode(new Uint8Array(25), 0, 1, [0]); });
-      assert.equal(sixels, '');
+      assert.strictEqual(sixels, '');
       assert.doesNotThrow(() => { sixels = sixelEncode(new Uint8Array(25), 1, 0, [0]); });
-      assert.equal(sixels, '');
+      assert.strictEqual(sixels, '');
     });
     it('wrong geometry should throw', () => {
-      assert.throws(() => { const sixels = sixelEncode(new Uint8Array(8), 1, 1, [0]); }, 'wrong geometry of data');
+      assert.throws(() => { sixelEncode(new Uint8Array(8), 1, 1, [0]); }, /wrong geometry of data/);
     });
     it('empty palette should throw', () => {
-      assert.throws(() => { const sixels = sixelEncode(new Uint8Array(4), 1, 1, []); }, 'palette must not be empty');
+      assert.throws(() => { sixelEncode(new Uint8Array(4), 1, 1, []); }, /palette must not be empty/);
     });
     describe('palette handling', () => {
       function getPalFromSixel(sixels: string): RGBA8888[] {
@@ -58,9 +58,9 @@ describe('encoding', () => {
         // compare with values read by decoder
         const dec = new SixelDecoder(0, []);
         dec.decodeString(sixels);
-        assert.deepEqual(getPalFromSixel(sixels), dec.palette);
-        assert.deepEqual(getPalFromSixel(sixels2), dec.palette);
-        assert.equal(getPalFromSixel(sixels).length, 2);
+        assert.deepStrictEqual(getPalFromSixel(sixels), dec.palette);
+        assert.deepStrictEqual(getPalFromSixel(sixels2), dec.palette);
+        assert.strictEqual(getPalFromSixel(sixels).length, 2);
       });
       it('should filter alpha=0 and doubles from palette', () => {
         const data = new Uint8Array(8);
@@ -76,9 +76,9 @@ describe('encoding', () => {
         // compare with values read by decoder
         const dec = new SixelDecoder(0, []);
         dec.decodeString(sixels);
-        assert.deepEqual(getPalFromSixel(sixels), dec.palette);
-        assert.deepEqual(getPalFromSixel(sixels2), dec.palette);
-        assert.equal(getPalFromSixel(sixels).length, 2);
+        assert.deepStrictEqual(getPalFromSixel(sixels), dec.palette);
+        assert.deepStrictEqual(getPalFromSixel(sixels2), dec.palette);
+        assert.strictEqual(getPalFromSixel(sixels).length, 2);
       });
     });
     it('skip raster attributes in output', () => {
@@ -86,10 +86,10 @@ describe('encoding', () => {
       data.fill(255);
       // default - contains raster attributes
       const sixels = sixelEncode(data, 2, 1, [[12, 34, 56], [98, 76, 54]]);
-      assert.equal(sixels.indexOf('"1;1;2;1'), 0);
+      assert.strictEqual(sixels.indexOf('"1;1;2;1'), 0);
       const sixels2 = sixelEncode(data, 2, 1, [[12, 34, 56], [98, 76, 54]], false);
-      assert.equal(sixels2.indexOf('"1;1;2;1'), -1);
-      assert.equal(sixels2, sixels.slice(8));
+      assert.strictEqual(sixels2.indexOf('"1;1;2;1'), -1);
+      assert.strictEqual(sixels2, sixels.slice(8));
     });
   });
   describe('encoding tests', () => {
@@ -98,7 +98,7 @@ describe('encoding', () => {
       data.fill(255);
       const sixels = sixelEncode(data, 5, 1, [[0, 0, 0], [255, 255, 255]]);
       // "#1" color slot[1], "!5" repeat 5, "@" 1st bit set
-      assert.equal(sixels.indexOf('#1!5@') !== -1, true);
+      assert.strictEqual(sixels.indexOf('#1!5@') !== -1, true);
     });
     it('4 repeating pixels', () => {
       const data = new Uint8Array(20);
@@ -108,7 +108,7 @@ describe('encoding', () => {
       const sixels = sixelEncode(data, 5, 1, [[0, 0, 0], [255, 255, 255]]);
       // "#0" color slot[0], "@" 1st bit set, "$" CR
       // "#1" color slot[1], "?" 0 bit set, "!4" repeat 4, "@" 1st bit set, "$" CR
-      assert.equal(sixels.indexOf('#0@$#1?!4@$') !== -1, true);
+      assert.strictEqual(sixels.indexOf('#0@$#1?!4@$') !== -1, true);
     });
     it('3 repeating pixels', () => {
       const data = new Uint8Array(20);
@@ -119,7 +119,7 @@ describe('encoding', () => {
       // "#0" color slot[0], "@@" 1st bit set, "$" CR
       // "#1" color slot[1], "?" 0 bit set, "@@@" 1st bit set, "$" CR
       // ==> ! length encoding for >3
-      assert.equal(sixels.indexOf('#0@@$#1??@@@$') !== -1, true);
+      assert.strictEqual(sixels.indexOf('#0@@$#1??@@@$') !== -1, true);
     });
     it('background pixel skipped', () => {
       const data = new Uint8Array(20);
@@ -129,7 +129,7 @@ describe('encoding', () => {
       const sixels = sixelEncode(data, 5, 1, [[0, 0, 0], [255, 255, 255]]);
       // "#0@$"     color[0] one pixel + CR
       // "#1??@@@$" color[1] skip 2 pixels + color 3 pixels + CR
-      assert.equal(sixels.indexOf('#0@$#1??@@@$') !== -1, true);
+      assert.strictEqual(sixels.indexOf('#0@$#1??@@@$') !== -1, true);
     });
   });
 });

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -34,3 +34,63 @@ export interface IQuantResult {
   /** array with quantized colors */
   palette: number[];
 }
+
+
+export interface ISixelDecoder {
+  /** basic image dimensions, either set upfront in ctor (wasm) or determined at runtime */
+  width: number;
+  height: number;
+  decode(data: UintTypedArray, start?: number, end?: number): void;
+  /** pixel data in RGBA32 */
+  data32: Uint32Array;
+
+  // upcoming settings
+  operationMode?: 'terminal' | 'printer';  // make terminal indirection working
+  palette: Uint32Array;                   // for real terminal-shared to get/set palette: []RGBA888
+
+  // questionable, yet easy to polyfill
+  rasterWidth?: number;
+  rasterHeight?: number;
+  rasterRatioNumerator?: number;
+  rasterRatioDenominator?: number;
+  fillColor?: RGBA8888;
+  memoryUsage?: number;
+  decodeString?(data: string, start: number, end: number): void;
+
+  // questionable, tricky to polyfill/to be removed
+  realWidth?: number;
+  realHeight?: number;
+  toPixelData?(): void;
+}
+
+export const enum SixelState {
+  DATA = 0,
+  COMPRESSION = 1,
+  ATTR = 2,
+  COLOR = 3
+}
+
+export const enum SixelAction {
+  IGNORE = 0,
+  DRAW = 1,
+  CR = 2,
+  LF = 3,
+  REPEATED_DRAW = 4,
+  STORE_PARAM = 5,
+  SHIFT_PARAM = 6,
+  APPLY_PARAM = 7
+}
+
+export interface ISixelDimensions {
+  // pixel ratio values (ignored by SixelDecoder)
+  numerator: number;
+  denominator: number;
+  // image width
+  width: number;
+  // image height
+  height: number;
+  // index in active chunk to continue decoding
+  index: number;
+  // SIXEL conformance level
+  level: 1 | 2;
+}

--- a/src/WasmDecoder.test.ts
+++ b/src/WasmDecoder.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2021 Joerg Breitbart.
+ * @license MIT
+ */
+
+import * as assert from 'assert';
+import { toRGBA8888 } from './Colors';
+import * as WASM_DATA from './wasm.json';
+import { WasmDecoder, WasmDecoderAsync } from './WasmDecoder';
+import * as fs from 'fs';
+
+function s2b(s: string): Uint8Array {
+  const result = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; ++i) {
+    result[i] = s.charCodeAt(i);
+  }
+  return result;
+}
+
+describe('WasmDecoder', () => {
+  it('should have loaded wasm data', () => {
+    assert.strictEqual(WASM_DATA.chunkSize, 4096);
+    assert.strictEqual(WASM_DATA.paletteSize, 4096);
+    assert.strictEqual(WASM_DATA.canvasSize, 1536 * 1536);
+    assert.strictEqual(WASM_DATA.bytes.length !== 0, true);
+  });
+  it('sync ctor', () => {
+    const dec = new WasmDecoder();
+    assert.notStrictEqual((dec as any)._instance, undefined);
+    assert.strictEqual(dec.palette.length, 4096);
+    assert.strictEqual(dec.data32.length, 0);   // uninitialized defaults to 0 x 0
+    assert.strictEqual(dec.width, 0);
+    assert.strictEqual(dec.height, 0);
+  });
+  it('async ctor', async () => {
+    assert.strictEqual(WasmDecoderAsync() instanceof Promise, true);
+    const dec = await WasmDecoderAsync();
+    assert.notStrictEqual((dec as any)._instance, undefined);
+    assert.strictEqual(dec.palette.length, 4096);
+    assert.strictEqual(dec.data32.length, 0);   // uninitialized defaults to 0 x 0
+    assert.strictEqual(dec.width, 0);
+    assert.strictEqual(dec.height, 0);
+  });
+  it('memory usage below 10MB', () => {
+    const dec = new WasmDecoder();
+    assert.strictEqual(dec.memoryUsage < 10 * 1024 * 1024, true);
+  });
+  it('init correctly sets width/height/palette/canvas', () => {
+    const dec = new WasmDecoder();
+    dec.init(10, 20, 0xFF00FF00, new Uint32Array([1, 2, 3, 4, 5]), 8);
+    assert.strictEqual(dec.width, 10);
+    assert.strictEqual(dec.height, 20);
+    assert.strictEqual(dec.palette.length, 8);
+    assert.deepStrictEqual(dec.palette, new Uint32Array([1, 2, 3, 4, 5, 0, 0, 0]));
+    assert.deepStrictEqual(dec.data32, new Uint32Array(10 * 20).fill(0xFF00FF00));
+    dec.init(5, 10, 0x00FF00FF, new Uint32Array([7, 8, 9]), 6);
+    assert.strictEqual(dec.width, 5);
+    assert.strictEqual(dec.height, 10);
+    assert.strictEqual(dec.palette.length, 6);
+    assert.deepStrictEqual(dec.palette, new Uint32Array([7, 8, 9, 4, 5, 0]));
+    assert.deepStrictEqual(dec.data32, new Uint32Array(5 * 10).fill(0x00FF00FF));
+  });
+  it('init should reject out of bound values', () => {
+    const dec = new WasmDecoder();
+    assert.throws(() => dec.init(-1, -1), /cannot use WasmDecoder/);
+    assert.throws(() => dec.init(2000, 2000), /cannot use WasmDecoder/);
+    assert.doesNotThrow(() => dec.init(100, 100, 0, new Uint32Array(10000)));
+    assert.throws(() => dec.init(100, 100, 0, new Uint32Array(16), 10000), /cannot use WasmDecoder/);
+  });
+  describe('decode', () => {
+    it('overflow width', () => {
+      const dec = new WasmDecoder();
+      dec.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('#0??????????'));  // ? - 0 in sixel
+      assert.deepStrictEqual(dec.data32, new Uint32Array(25).fill(0));
+  
+      dec.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('#0@@@@@@@@@@'));  // @ - 1 in sixel
+      assert.deepStrictEqual(dec.data32, new Uint32Array(25).fill(0).fill(255, 0, 5));
+  
+      dec.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('#0AAAAAAAAAA'));  // A - 2 in sixel
+      assert.deepStrictEqual(dec.data32, new Uint32Array(25).fill(0).fill(255, 5, 10));
+    });
+    it('overflow width with repeat', () => {
+      const dec = new WasmDecoder();
+      dec.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('#0!20?'));  // ? - 0 in sixel
+      assert.deepStrictEqual(dec.data32, new Uint32Array(25).fill(0));
+  
+      dec.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('#0!20@'));  // @ - 1 in sixel
+      assert.deepStrictEqual(dec.data32, new Uint32Array(25).fill(0).fill(255, 0, 5));
+  
+      dec.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('#0!20A'));  // A - 2 in sixel
+      assert.deepStrictEqual(dec.data32, new Uint32Array(25).fill(0).fill(255, 5, 10));
+    });
+    it('overflow height', () => {
+      const dec = new WasmDecoder();
+      dec.init(10, 6, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('-#0@')); // jumps to x=0,y=6: first pixel line behind and multiple of 6
+      assert.deepStrictEqual((dec as any)._canvas.subarray(0, 100), new Uint32Array(100).fill(0));
+
+      dec.init(10, 7, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('-#0@@@@@')); // jumps to x=0,y=6, should draw in last line
+      assert.deepStrictEqual((dec as any)._canvas.subarray(0, 100), new Uint32Array(100).fill(0).fill(255, 60, 65));
+
+      dec.init(10, 7, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('-#0!20~')); // jumps to x=0,y=6, this time overdrawing 5 more pixels in height
+      assert.deepStrictEqual(
+        (dec as any)._canvas.subarray(0, 150),
+        new Uint32Array(150).fill(0).fill(255, 60, 60 + 6*10)
+      );
+
+      dec.init(10, 7, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec.decode(s2b('-#0!20~$---#0!20~')); // jumps to x=0,y=6, should not draw the second part
+      assert.deepStrictEqual(
+        (dec as any)._canvas.subarray(0, 150),
+        new Uint32Array(150).fill(0).fill(255, 60, 60 + 6*10)
+      );
+    });
+    it('decodeString', () => {
+      const dec1 = new WasmDecoder();
+      dec1.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec1.decode(s2b('#0AAAAAAAAAA'));
+      const dec2 = new WasmDecoder();
+      dec2.init(5, 5, 0, new Uint32Array([toRGBA8888(255, 0, 0, 0)]), 1);
+      dec2.decodeString('#0AAAAAAAAAA');
+      assert.deepStrictEqual(dec2.data32, dec1.data32);
+    });
+    it('decodeString - real image', () => {
+      const bdata = fs.readFileSync('./testfiles/test1_clean.sixel');
+      const sdata = fs.readFileSync('./testfiles/test1_clean.sixel', 'utf-8');
+      const dec1 = new WasmDecoder();
+      dec1.init(1280, 720, 0, null, 256);
+      dec1.decode(bdata);
+      const dec2 = new WasmDecoder();
+      dec2.init(1280, 720, 0, null, 256);
+      dec2.decodeString(sdata);
+      assert.deepStrictEqual(dec2.data32, dec1.data32);
+      assert.deepStrictEqual(dec2.data32, dec1.data32);
+    });
+  });
+});

--- a/src/WasmDecoder.ts
+++ b/src/WasmDecoder.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2021 Joerg Breitbart.
+ * @license MIT
+ */
+
+import { ISixelDecoder, RGBA8888, UintTypedArray } from './Types';
+import { DEFAULT_BACKGROUND, PALETTE_VT340_COLOR } from './Colors';
+import * as WASM_DATA from './wasm.json';
+
+
+interface IWasmInternalExports extends Record<string, WebAssembly.ExportValue> {
+  memory: WebAssembly.Memory;
+  get_chunk_address(): number;
+  get_canvas_address(): number;
+  get_palette_address(): number;
+  get_canvas_limit(): number;
+  get_chunk_limit(): number;
+  get_palette_limit(): number;
+  init(width: number, height: number, fillColor: number, paletteLimit: number): void;
+  decode(length: number): void;
+}
+
+
+/* istanbul ignore next */
+function decodeBase64(s: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(s, 'base64');
+  }
+  const bytestring = atob(s);
+  const result = new Uint8Array(bytestring.length);
+  for (let i = 0; i < result.length; ++i) {
+    result[i] = bytestring.charCodeAt(i);
+  }
+  return result;
+}
+
+
+const WASM = {
+  CHUNK_SIZE: WASM_DATA.chunkSize,
+  CANVAS_SIZE: WASM_DATA.canvasSize,
+  PALETTE_SIZE: WASM_DATA.paletteSize,
+  BYTES: decodeBase64(WASM_DATA.bytes)
+};
+const DEFAULT_PALETTE = new Uint32Array(PALETTE_VT340_COLOR);
+
+
+/**
+ * Helper to check, if an image can be decoded with the WASM decoder.
+ * The dimension of the data stream can be pulled with `DimensionDecoder` beforehand.
+ */
+export function canUseWasm(width: number, height: number, paletteLimit: number): boolean {
+  if (width > 0 && height > 0
+    && width * Math.ceil(height / 6) * 6 <= WASM.CANVAS_SIZE
+    && paletteLimit <= WASM.PALETTE_SIZE
+  ) {
+    return true;
+  }
+  return false;
+}
+
+
+/**
+ * Create a WasmDecoder instance asynchronously.
+ * To be used in the browser main thread.
+ */
+export function WasmDecoderAsync(): Promise<WasmDecoder> {
+  return WebAssembly.instantiate(WASM.BYTES).then(inst => new WasmDecoder(inst.instance))
+}
+
+/**
+ * WasmDecoder - decoder in WebAssembly.
+ *
+ * This is a fast level 2 decoder, which always truncates pixels at raster width/height.
+ * While this behavior is not spec conform, it is what most people want for SIXEL output.
+ * Currently it only operates in printer mode, thus color changes get immediately applied.
+ *
+ * Further restrictions:
+ *  - up to max CANVAS_SIZE pixels (default 1536 x 1536)
+ *  - up to max PALETTE_SIZE colors (default 4096)
+ *
+ * A decoder instance is meant to be reused:
+ *  - pull image dimensions from `DimensionDecoder`
+ *  - call `init` with dimensions to prepare for the new image
+ *  - subsequent `decode` calls
+ *  - pull pixel data from `data32` (as RGBA32)
+ *
+ * Note: All typed array buffers exposed are borrowed from the WASM memory,
+ * thus you have to copy things over if you want to persist data. Affected:
+ *  - palette:  memory view clamped to [0 .. paletteLimit]
+ *  - data32:   memory view clamped to [0 .. width * height]
+ *
+ * Note on WASM: For better performance the WASM code tries to minimize memory interaction,
+ * e.g. everything is static memory (alloc free). The canvas memory will only be flushed
+ * by a next `init` call up to the given dimensions. This static nature might impose security
+ * issues for sensitive image data. To avoid that, either do a manual flush by calling `init`
+ * with max CANVAS_SIZE, or throw away the decoder instance.
+ * 
+ * Note on endianess: WASM operates internally in LE. We set and retrieve colors from RGBA8888
+ * 32bit words, which are endianess dependent (ABGR32 vs. RGBA32). But since we only operate
+ * on the full 32bit words everywhere, it should not impact anything. Yet this remains
+ * uncertain until actually tested.
+ */
+export class WasmDecoder implements ISixelDecoder {
+  private _wasm: IWasmInternalExports;
+  private _chunk: Uint8Array;
+  private _canvas: Uint32Array;
+  private _palette: Uint32Array;
+  private _paletteLimit = WASM.PALETTE_SIZE;
+  private _data32: Uint32Array | undefined;
+
+  public width = 0;
+  public height = 0;
+
+  /**
+   * Synchonous ctor. Can be called from nodejs or a webworker context.
+   * For instantiation in the browser main thread use `WasmDecoderAsync` instead.
+   */
+  constructor(private _instance?: WebAssembly.Instance) {
+    if (!_instance) {
+      this._instance = new WebAssembly.Instance(new WebAssembly.Module(WASM.BYTES));
+    }
+    this._wasm = this._instance.exports as IWasmInternalExports;
+    this._chunk = new Uint8Array(this._wasm.memory.buffer, this._wasm.get_chunk_address(), WASM.CHUNK_SIZE);
+    this._canvas = new Uint32Array(this._wasm.memory.buffer, this._wasm.get_canvas_address(), WASM.CANVAS_SIZE);
+    this._palette = new Uint32Array(this._wasm.memory.buffer, this._wasm.get_palette_address(), WASM.PALETTE_SIZE);
+  }
+
+  /**
+   * Prepare for a new image.
+   *
+   * `width` and `height` can be obtained from `DimensionDecoder`.
+   * `fillColor` is a RGBA8888 value, default is black.
+   * `palette` may not exceed WASM.PALETTE_SIZE, default is PALETTE_VT340_COLOR.
+   * If unset, the palette colors of the previous decoding will be used (initially all zero).
+   * `paletteLimit` restricts the used registers further (higher registers are mapped back
+   * into valid ones with modulo). Default is WASM.PALETTE_SIZE.
+   *
+   * The method may throw an error, if the WASM memory restrictions are not met.
+   */
+  public init(
+    width: number,
+    height: number,
+    fillColor: RGBA8888 = DEFAULT_BACKGROUND,
+    palette: Uint32Array = DEFAULT_PALETTE,
+    paletteLimit: number = WASM.PALETTE_SIZE
+  ): void {
+    if (!canUseWasm(width, height, paletteLimit)) {
+      this.width = 0;
+      this.height = 0;
+      throw new Error('cannot use WasmDecoder');
+    }
+    this._wasm.init(width, height, fillColor, paletteLimit);
+    this._paletteLimit = paletteLimit;
+    this._data32 = undefined;
+    this.width = width;
+    this.height = height;
+    if (palette) {
+      this._palette.set(palette.subarray(0, WASM.PALETTE_SIZE));
+    }
+  }
+
+  /**
+   * Decode next chunk of data from start to end (exclusive).
+   */
+  public decode(data: UintTypedArray, start: number = 0, end: number = data.length): void {
+    let p = start;
+    while (p < end) {
+      const length = Math.min(end - p, WASM.CHUNK_SIZE);
+      this._chunk.set(data.subarray(p, p += length));
+      this._wasm.decode(length);
+    }
+  }
+
+  /**
+   * Decode next chunk of string data from start to end (exclusive).
+   */
+  public decodeString(data: string, start: number = 0, end: number = data.length): void {
+    let p = start;
+    while (p < end) {
+      const length = Math.min(end - p, WASM.CHUNK_SIZE);
+      for (let i = 0, j = p; i < length; ++i, ++j) {
+        this._chunk[i] = data.charCodeAt(j);
+      }
+      p += length;
+      this._wasm.decode(length);
+    }
+  }
+
+  /**
+   * Get current pixel data as RGBA8888[] (borrowed).
+   */
+  public get data32(): Uint32Array {
+    if (!this._data32) {
+      this._data32 = this._canvas.subarray(0, this.width * this.height);
+    }
+    return this._data32;
+  }
+
+  /**
+   * Get active palette colors as RGBA8888[] (borrowed).
+   */
+  public get palette(): Uint32Array {
+    return this._palette.subarray(0, this._paletteLimit);
+  }
+
+  /**
+   * Get the memory used by the wasm instance.
+   */
+  public get memoryUsage(): number {
+    return this._wasm.memory.buffer.byteLength;
+  }
+}

--- a/src/index.benchmark.ts
+++ b/src/index.benchmark.ts
@@ -3,10 +3,12 @@
  * @license MIT
  */
 
-import { RuntimeCase, perfContext } from 'xterm-benchmark';
+import { RuntimeCase, perfContext, before, beforeEach, ThroughputRuntimeCase } from 'xterm-benchmark';
 import { toRGBA8888, SixelDecoder, introducer, FINALIZER, sixelEncode } from './index';
 import * as fs from 'fs';
 import { RGBA8888 } from './Types';
+import { DimensionDecoder } from './DimensionDecoder';
+import { WasmDecoder } from './WasmDecoder';
 
 
 // test data: 9-bit palette in 10x10 tiles (512 colors: 8*8*8) - 640x80 -> 6 rows => 640x480
@@ -79,34 +81,46 @@ perfContext('testimage', () => {
     dec.decode(SIXELBYTES);
     new RuntimeCase('toPixelData - with fillColor', () => {
       return dec.toPixelData(TARGET, 640, 480, 0, 0, 0, 0, 640, 480, toRGBA8888(0, 0, 0));
-    }, {repeat: 10}).showAverageRuntime();
+    }, {repeat: 20}).showAverageRuntime();
     new RuntimeCase('toPixelData - without fillColor', () => {
       return dec.toPixelData(TARGET, 640, 480, 0, 0, 0, 0, 640, 480, 0);
-    }, {repeat: 10}).showAverageRuntime();
+    }, {repeat: 20}).showAverageRuntime();
   });
 
-  perfContext('decode', () => {
+  perfContext('decode (DefaultDecoder)', () => {
     new RuntimeCase('decode', () => {
       const dec = new SixelDecoder();
       dec.decode(SIXELBYTES);
       return dec.width;
-    }, {repeat: 10}).showAverageRuntime();
+    }, {repeat: 20}).showAverageRuntime();
     new RuntimeCase('decodeString', () => {
       const dec = new SixelDecoder();
       dec.decodeString(SIXELSTRING);
       return dec.width;
-    }, {repeat: 10}).showAverageRuntime();
+    }, {repeat: 20}).showAverageRuntime();
     new RuntimeCase('decode + pixel transfer', () => {
       const dec = new SixelDecoder();
       dec.decode(SIXELBYTES);
       return dec.toPixelData(TARGET, 640, 480, 0, 0, 0, 0, 640, 480, 0);
-    }, {repeat: 10}).showAverageRuntime();
+    }, {repeat: 20}).showAverageRuntime();
+  });
+
+  perfContext('decode (WasmDecoder)', () => {
+    const wasmDec = new WasmDecoder();
+    new RuntimeCase('decode', () => {
+      wasmDec.init(640, 480);
+      wasmDec.decode(SIXELBYTES);
+    }, {repeat: 20}).showAverageRuntime();
+    new RuntimeCase('decodeString', () => {
+      wasmDec.init(640, 480);
+      wasmDec.decodeString(SIXELSTRING);
+    }, {repeat: 20}).showAverageRuntime();
   });
 
   perfContext('encode', () => {
     new RuntimeCase('sixelEncode', () => {
       return sixelEncode(SOURCE8, 640, 480, PALETTE).length;
-    }, {repeat: 10}).showAverageRuntime();
+    }, {repeat: 20}).showAverageRuntime();
     // }, {repeat: 1, fork: true, forkOptions: {execArgv: ['--inspect-brk']}}).showAverageRuntime();
   });
 });
@@ -114,22 +128,81 @@ perfContext('testimage', () => {
 
 const TEST1 = fs.readFileSync(__dirname + '/../testfiles/test1_clean.sixel');
 const TEST2 = fs.readFileSync(__dirname + '/../testfiles/test2_clean.sixel');
-const SAMPSA = fs.readFileSync(__dirname + '/../testfiles/sampsa1_clean.sixel');
+const SAMPSA = fs.readFileSync(__dirname + '/../testfiles/sampsa_reencoded_clean.six');
 
-perfContext('decode - testfiles', () => {
-  new RuntimeCase('test1_clean.sixel', () => {
+// create 1920 x 1080 random noise in 12bit-RGB
+// const channelValues = Array.from(Array(16).keys()).map(v => v * 16);
+// const palette: RGBA8888[] = [];
+// for (let r = 0; r < channelValues.length; ++r) {
+//   for (let g = 0; g < channelValues.length; ++g) {
+//     for (let b = 0; b < channelValues.length; ++b) {
+//       palette.push(toRGBA8888(channelValues[r], channelValues[g], channelValues[b]));
+//     }
+//   }
+// }
+// const pixels = new Uint32Array(2073600);
+// for (let i = 0; i < pixels.length; ++i) {
+//   pixels[i] = palette[Math.floor(Math.random() * 4096)];
+// }
+// const NOISE_STRING = sixelEncode(new Uint8Array(pixels.buffer), 1920, 1080, palette);
+// fs.writeFileSync('testfiles/fullhd_12bit_noise_clean.six', NOISE_STRING);
+const NOISE = fs.readFileSync(__dirname + '/../testfiles/fullhd_12bit_noise_clean.six');
+
+perfContext('decode - testfiles (DefaultDecoder)', () => {
+  new ThroughputRuntimeCase('test1_clean.sixel', () => {
     const dec = new SixelDecoder();
     dec.decode(TEST1);
-    return dec.width;
-  }, {repeat: 10}).showAverageRuntime();
-  new RuntimeCase('test2_clean.sixel', () => {
+    return {payloadSize: TEST1.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
+  new ThroughputRuntimeCase('test2_clean.sixel', () => {
     const dec = new SixelDecoder();
     dec.decode(TEST2);
-    return dec.width;
-  }, {repeat: 10}).showAverageRuntime();
-  new RuntimeCase('sampsa1_clean.sixel', () => {
+    return {payloadSize: TEST2.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
+  new ThroughputRuntimeCase('sampsa_reencoded_clean.six', () => {
     const dec = new SixelDecoder();
     dec.decode(SAMPSA);
-    return dec.width;
-  }, {repeat: 10}).showAverageRuntime();
+    return {payloadSize: SAMPSA.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
+  new ThroughputRuntimeCase('FullHD 12bit noise', () => {
+    const dec = new SixelDecoder();
+    dec.decode(NOISE);
+    return {payloadSize: NOISE.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
+});
+
+perfContext('decode - testfiles (WasmDecoder)', () => {
+  let dimDec: DimensionDecoder;
+  let wasmDec: WasmDecoder;
+  before(() => {
+    dimDec = new DimensionDecoder();
+    wasmDec = new WasmDecoder();
+  });
+  beforeEach(() => {
+    dimDec.reset();
+  });
+  new ThroughputRuntimeCase('test1_clean.sixel', () => {
+    const dim = dimDec.decode(TEST1);
+    wasmDec.init(dim.width, dim.height);
+    wasmDec.decode(TEST1);
+    return {payloadSize: TEST1.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
+  new ThroughputRuntimeCase('test2_clean.sixel', () => {
+    const dim = dimDec.decode(TEST2);
+    wasmDec.init(dim.width, dim.height);
+    wasmDec.decode(TEST2);
+    return {payloadSize: TEST2.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
+  new ThroughputRuntimeCase('sampsa_reencoded_clean.six', () => {
+    const dim = dimDec.decode(SAMPSA);
+    wasmDec.init(dim.width, dim.height);
+    wasmDec.decode(SAMPSA);
+    return {payloadSize: SAMPSA.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
+  new ThroughputRuntimeCase('FullHD 12bit noise', () => {
+    const dim = dimDec.decode(NOISE);
+    wasmDec.init(dim.width, dim.height);
+    wasmDec.decode(NOISE);
+    return {payloadSize: NOISE.length};
+  }, {repeat: 20}).showAverageRuntime().showAverageThroughput();
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { SixelDecoder, toRGBA8888, sixelEncode } from './index';
 import { RGBA8888 } from './Types';
 
@@ -29,10 +29,10 @@ describe('encode - decode cycles', () => {
     imgDec.decodeString(sixels);
     imgDec.toPixelData(target8.subarray(0, 10 * 4), 10, 1);
     // compare
-    assert.deepEqual(target8, source8);
-    assert.equal(imgDec.width, 10);
-    assert.equal(imgDec.height, 1);
-    assert.equal(imgDec.memUsage, 16 * 6 * 4);  // 4 --> 8 --> 16 * 6 * 4
+    assert.deepStrictEqual(target8, source8);
+    assert.strictEqual(imgDec.width, 10);
+    assert.strictEqual(imgDec.height, 1);
+    assert.strictEqual(imgDec.memUsage, 16 * 6 * 4);  // 4 --> 8 --> 16 * 6 * 4
   });
   it('1x10 black', () => {
     // prepare data
@@ -44,11 +44,11 @@ describe('encode - decode cycles', () => {
     imgDec.decodeString(sixels);
     imgDec.toPixelData(target8.subarray(0, 10 * 4), 1, 10);
     // compare
-    assert.deepEqual(target8, source8);
-    assert.equal(imgDec.width, 1);
-    assert.equal(imgDec.height, 10);
-    assert.equal(imgDec.realHeight, 10);
-    assert.equal(imgDec.memUsage, (4 + 1) * 6 * 4); // (4 + 1) * 6 * 4
+    assert.deepStrictEqual(target8, source8);
+    assert.strictEqual(imgDec.width, 1);
+    assert.strictEqual(imgDec.height, 10);
+    assert.strictEqual(imgDec.realHeight, 10);
+    assert.strictEqual(imgDec.memUsage, (4 + 1) * 6 * 4); // (4 + 1) * 6 * 4
   });
   it('10x1 with 8 colors', () => {
     // prepare data
@@ -70,9 +70,9 @@ describe('encode - decode cycles', () => {
     imgDec.decodeString(sixels);
     imgDec.toPixelData(target8.subarray(0, 8 * 4), 8, 1);
     // compare
-    assert.deepEqual(target8, source8);
-    assert.equal(imgDec.width, 8);
-    assert.equal(imgDec.height, 1);
+    assert.deepStrictEqual(target8, source8);
+    assert.strictEqual(imgDec.width, 8);
+    assert.strictEqual(imgDec.height, 1);
   });
   it('100x100 with 256 random colors (noise)', () => {
     // prepare data
@@ -104,11 +104,11 @@ describe('encode - decode cycles', () => {
     imgDec.decodeString(sixels);
     imgDec.toPixelData(target8, 100, 100);
     // compare
-    assert.deepEqual(target8, source8);
-    assert.equal(imgDec.width, 100);
-    assert.equal(imgDec.height, 100);
+    assert.deepStrictEqual(target8, source8);
+    assert.strictEqual(imgDec.width, 100);
+    assert.strictEqual(imgDec.height, 100);
     // 4 --> 8 --> 16 --> 32 --> 64 --> 128 * 6 * 4
     // + 16 * 100 * 6 * 4
-    assert.equal(imgDec.memUsage, 128 * 6 * 4 + 16 * 100 * 6 * 4);
+    assert.strictEqual(imgDec.memUsage, 128 * 6 * 4 + 16 * 100 * 6 * 4);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,5 @@ export { RGBA8888, RGBColor } from './Types';
 export { toRGBA8888, fromRGBA8888, DEFAULT_BACKGROUND, PALETTE_ANSI_256, PALETTE_VT340_COLOR, PALETTE_VT340_GREY } from './Colors';
 export { SixelDecoder } from './SixelDecoder';
 export { sixelEncode, introducer, FINALIZER, image2sixel } from './SixelEncoder';
+export { DimensionDecoder } from './DimensionDecoder';
+export { WasmDecoder, WasmDecoderAsync, canUseWasm } from './WasmDecoder';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "lib",
     "sourceMap": true,
     "declaration": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "resolveJsonModule": true
   },
   "exclude": [
     "node_modules",

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+#################################
+# compile time decoder settings #
+#################################
+
+# EMSCRIPTEN_PATH
+# Path to your emscripten SDK.
+EMSCRIPTEN_PATH=../../../playground/emsdk/emsdk_env.sh
+
+# CHUNK_SIZE
+# Maximum size of a single chunk, that can be loaded into the decoder.
+# This has only a tiny impact on the decoder speed, thus we can go with
+# a rather low value (aligned with typical PIPE_BUF values).
+# Use one of 2 ^ (12 .. 16).
+CHUNK_SIZE=4096
+
+# CANVAS_SIZE
+# Maximum amount of pixels the internal canvas can hold.
+# This value has a huge impact on the allocated static memory,
+# as every pixels is stored as RGBA32. Therefore thus the default is choosen
+# to deal with images up to FullHD (~10 MB memory per decoder instance).
+CANVAS_SIZE=$((1536 * 1536))
+
+# PALETTE_SIZE
+# Maximum color slots the internal palette can hold.
+# Most SIXEL images never have more than 256 (demanded by the spec).
+# We use a much higher default of 4096, thus can deal up to 12bit-RGB.
+# Use one of 2 ^ (8 .. 16).
+PALETTE_SIZE=4096
+
+# INITIAL_MEMORY
+# This is the total memory the wasm instance will occupy.
+# Always adjust this after changes to values above.
+# If not enough memory was given, emscripten will throw a linking error.
+# This can be used to spot the real usage and round it up to the next 64KiB multiple.
+INITIAL_MEMORY=$((145 * 65536))
+
+
+
+
+##################
+# compile script #
+##################
+
+cd wasm
+
+# activate emscripten env
+source $EMSCRIPTEN_PATH
+
+# compile with customizations
+emcc -O3 \
+-DCHUNK_SIZE=$CHUNK_SIZE \
+-DCANVAS_SIZE=$CANVAS_SIZE \
+-DPALETTE_SIZE=$PALETTE_SIZE \
+-s ASSERTIONS=0 \
+-s SUPPORT_ERRNO=0 \
+-s TOTAL_STACK=16384 \
+-s MALLOC=none \
+-s INITIAL_MEMORY=$INITIAL_MEMORY \
+-s MAXIMUM_MEMORY=$INITIAL_MEMORY \
+-s EXPORTED_FUNCTIONS='[
+  "_init",
+  "_decode",
+  "_get_chunk_address",
+  "_get_canvas_address",
+  "_get_palette_address",
+  "_get_chunk_limit",
+  "_get_canvas_limit",
+  "_get_palette_limit"
+]' \
+--no-entry decoder.cpp -o sixel.wasm
+
+# wrap wasm bytes into JSON file
+node wrap_wasm.js $CHUNK_SIZE $CANVAS_SIZE $PALETTE_SIZE

--- a/wasm/decoder.cpp
+++ b/wasm/decoder.cpp
@@ -1,0 +1,303 @@
+/**
+ * WasmDecoder - static instance SIXEL decoder with fixed canvas limit.
+ * 
+ * Copyright (c) 2021 Joerg Breitbart.
+ * @license MIT
+ */
+
+
+// cmdline overridable defines
+#ifndef CHUNK_SIZE
+  #define CHUNK_SIZE 4096
+#endif
+#ifndef CANVAS_SIZE
+  #define CANVAS_SIZE 1024 * 1024
+#endif
+#ifndef PALETTE_SIZE
+  #define PALETTE_SIZE 256
+#endif
+
+// internal defines
+#define  ST_DATA 0
+#define  ST_COMPRESSION 1
+#define  ST_ATTR 2
+#define  ST_COLOR 3
+
+#define PARAM_SIZE 6
+
+
+// static parser state
+struct ParserState {
+  int width;
+  int height;
+  int state;
+  int color;
+  int cursor;
+  int y_offset;
+  int offset;
+  int not_aborted;
+  int p_length;
+  int palette_length;
+  int jump_offsets[6];
+  int params[PARAM_SIZE];
+  int palette[PALETTE_SIZE];
+  char chunk[CHUNK_SIZE];
+  int canvas[CANVAS_SIZE];
+};
+static struct ParserState ps;
+
+
+// IO memory
+//static char CHUNK[CHUNK_SIZE];    // input data chunks
+//static int CANVAS[CANVAS_SIZE];   // output pixel canvas in RGBA32
+
+
+// exported functions
+extern "C" {
+  void* get_chunk_address() { return &ps.chunk[0]; }
+  void* get_canvas_address() { return &ps.canvas[0]; }
+  void* get_palette_address() { return &ps.palette[0]; }
+  int get_chunk_limit() { return CHUNK_SIZE; }
+  int get_canvas_limit() { return CANVAS_SIZE; }
+  int get_palette_limit() { return PALETTE_SIZE; }
+
+  void init(int width, int height, int fill_color, int palette_length);
+  void decode(int length);
+}
+
+/**
+ * Some inline helpers.
+ */
+
+// Put a single a single sixel at current cursor position.
+// Note: does not alter cursor position.
+inline void put_single(int code, int color) {
+  if (code && ps.cursor < ps.width && ps.y_offset < ps.height) {
+    int p = ps.cursor + ps.offset;
+    if (code & 1) ps.canvas[p] = color;
+    if (code & 2) ps.canvas[p + ps.jump_offsets[1]] = color;
+    if (code & 4) ps.canvas[p + ps.jump_offsets[2]] = color;
+    if (code & 8) ps.canvas[p + ps.jump_offsets[3]] = color;
+    if (code & 16) ps.canvas[p + ps.jump_offsets[4]] = color;
+    if (code & 32) ps.canvas[p + ps.jump_offsets[5]] = color;
+  }
+}
+
+// Put sixel n-times from current cursor position.
+// Note: does not alter cursor position.
+inline void put(int code, int color, int n) {
+  if (code && ps.cursor < ps.width && ps.y_offset < ps.height) {
+    if (ps.cursor + n >= ps.width) {
+      n = ps.width - ps.cursor;
+    }
+    int p = ps.cursor + ps.offset;
+    for (int i = 0; i < 6; ++i) {
+      if (code & (1 << i)) {
+        int pp = p + ps.jump_offsets[i];
+        for (int r = 0; r < n; ++r) {
+          ps.canvas[pp + r] = color;
+        }
+      }
+    }
+  }
+}
+
+// State jump helper.
+inline void jump(int code) {
+  switch (code) {
+    case 33:
+      ps.state = ST_COMPRESSION;
+      break;
+    case 35:
+      ps.state = ST_COLOR;
+      break;
+    case 36:
+      ps.cursor = 0;
+      break;
+    case 45:
+      ps.y_offset += 6;
+      ps.offset = ps.y_offset * ps.width;
+      ps.cursor = 0;
+      break;
+    case 34:
+      ps.state = ST_ATTR;
+      break;
+  }
+}
+
+// Reset params array to [0], always length 1 based (ZDM like).
+inline void params_reset() {
+  ps.params[0] = 0;
+  ps.p_length = 1;
+}
+// Add a param to params.
+inline void params_add_param() {
+  if (ps.p_length < PARAM_SIZE) {
+    ps.params[ps.p_length++] = 0;
+  }
+}
+// Add a decimal digit to current param.
+inline void params_add_digit(int v) {
+  if (ps.p_length < PARAM_SIZE) {
+    ps.params[ps.p_length - 1] = ps.params[ps.p_length - 1] * 10 + v;
+  }
+}
+
+// Normalize %-based SIXEL RGB 0..100 to channel byte values 0..255.
+// Note: does some rounding in integer arithmetics.
+inline int normalize_rgb(int r, int g, int b) {
+  return 0xFF000000 | ((b * 255 + 99) / 100) << 16 | ((g * 255 + 99) / 100) << 8 | ((r * 255 + 99) / 100);
+}
+
+
+/**
+ * @brief Initialize a new SIXEL image.
+ * 
+ * This works pretty much like a constructor, but other than with real memory isolated instances we operate
+ * on static memory flushing the old state. Therefore the decoder can only process one image at a time.
+ * If you need interleaved decoding of multiple images, consider spawning multiple wasm decoder instances.
+ * 
+ * @param width       Pixel width of the image to be decoded.
+ * @param height      Pixel height of the image to be decoded.
+ * @param fill_color  Fillcolor in RGBA8888 to initialize canvas with (LE only currently).
+ */
+void init(int width, int height, int fill_color, int palette_length) {
+  ps.not_aborted = 1;
+  ps.state = ST_DATA;
+  ps.color = 0;
+  ps.cursor = 0;
+  ps.y_offset = 0;
+  ps.offset = 0;
+  ps.palette_length = (0 < palette_length && palette_length < PALETTE_SIZE) ? palette_length : PALETTE_SIZE;
+  params_reset();
+
+  // basic overflow check
+  // Note: The height adjustment here is needed to avoid a potential overflow in the last sixel line.
+  // By adjusting here to multiples of 6 we reduce the usable canvas a bit, but can avoid nasty special
+  // case branching in put.
+  if (width == 0 || width > 0xFFFF || height == 0 || height > 0xFFFF || width * (height + 5) / 6 > CANVAS_SIZE) {
+    ps.not_aborted = 0;
+    ps.width = 0;
+    ps.height = 0;
+    return;
+  }
+
+  ps.width = width;
+  ps.height = height;
+
+  // clear canvas with fill_color
+  int p = 0;
+  for (int y = 0; y < ps.height; ++y) {
+    for (int x = 0; x < ps.width; ++x) {
+      ps.canvas[p + x] = fill_color;
+    }
+    p = p + ps.width;
+  }
+
+  // calc sixel pixel line jump offsets
+  for (int i = 0, v = 0; i < 6; ++i, v += ps.width) {
+    ps.jump_offsets[i] = v;
+  }
+}
+
+
+/**
+ * @brief Decode length bytes of the data loaded to chunk.
+ */
+void decode(int length) {
+  if (ps.not_aborted && ps.y_offset < ps.height) {
+    for (int i = 0; i < length; ++i) {
+      int code = ps.chunk[i] & 0x7F;
+      switch (ps.state) {
+        case ST_DATA:
+          if (code > 62 && code != 127) {
+            put_single(code - 63, ps.color);
+            ps.cursor++;
+          } else jump(code);
+          break;
+        case ST_COMPRESSION:
+          if (code > 47 && code < 58) {
+            params_add_digit(code - 48);
+          } else if (code > 62 && code != 127) {
+            put(code - 63, ps.color, ps.params[0]);
+            ps.cursor += ps.params[0];
+            params_reset();
+            ps.state = ST_DATA;
+          } else switch (code) {
+            case 33:
+              params_add_param();
+              break;
+            case 35:
+              params_reset();
+              ps.state = ST_COLOR;
+              break;
+            case 36:
+              params_reset();
+              ps.cursor = 0;
+              break;
+            case 45:
+              params_reset();
+              ps.y_offset += 6;
+              ps.offset = ps.y_offset * ps.width;
+              ps.cursor = 0;
+              break;
+            case 34:
+              params_reset();
+              ps.cursor = ST_ATTR;
+              break;
+          }
+          break;
+        case ST_COLOR:
+          if (code > 47 && code < 58) {
+            params_add_digit(code - 48);
+          } else if (code == 59) {
+            params_add_param();
+          } else if ((code > 62  && code != 127) || code == 33 || code == 35 || code == 36 || code == 45) {
+            if (ps.p_length == 1) {
+              ps.color = ps.palette[ps.params[0] % ps.palette_length];
+            } else if (ps.p_length == 5) {
+              if (ps.params[1] < 3
+                && ps.params[1] == 1 ? ps.params[2] <= 360 : ps.params[2] <= 100
+                && ps.params[2] <= 100
+                && ps.params[3] <= 100) {
+                switch (ps.params[1]) {
+                  case 2:  // RGB
+                    ps.color = ps.palette[ps.params[0] % ps.palette_length] = normalize_rgb(
+                      ps.params[2], ps.params[3], ps.params[4]);
+                    break;
+                  case 1:  // HLS
+                    // FIXME: port HLS calc
+                    ps.color = ps.palette[ps.params[0] % ps.palette_length] = normalize_rgb(
+                      ps.params[2], ps.params[3], ps.params[4]);
+                    break;
+                  case 0:  // illegal, only apply color switch
+                    ps.color = ps.palette[ps.params[0] % ps.palette_length];
+                }
+              }
+            }
+            params_reset();
+            if (code > 62 && code != 127) {
+              put_single(code - 63, ps.color);
+              ps.cursor++;
+              ps.state = ST_DATA;
+            } else jump(code);
+          }
+          break;
+        case ST_ATTR:
+          if (code > 47 && code < 58) {
+            params_add_digit(code - 48);
+          } else if (code == 59) {
+            params_add_param();
+          } else {
+            params_reset();
+            if (code > 62 && code != 127) {
+              put_single(code - 63, ps.color);
+              ps.cursor++;
+              ps.state = ST_DATA;
+            } else jump(code);
+          }
+          break;
+      }
+    }
+  }
+}

--- a/wasm/wrap_wasm.js
+++ b/wasm/wrap_wasm.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+
+const wasmData = JSON.stringify({
+  chunkSize: parseInt(process.argv[2]),
+  canvasSize: parseInt(process.argv[3]),
+  paletteSize: parseInt(process.argv[4]),
+  bytes: fs.readFileSync('sixel.wasm').toString('base64')
+});
+
+// also overwrite src target in case a bundler pulls from TS source folders
+fs.writeFileSync('../lib/wasm.json', wasmData);
+fs.writeFileSync('../src/wasm.json', wasmData);


### PR DESCRIPTION
The PR introduces a webassembly decoder for faster decoding. Speedup is ~2x.

The wasm decoder comes with several restrictions for now:
- level 2 only truncating at raster width/height
- static fixed memory (limited to 1536 x 1536 pixels and 4096 palette colors)
- printer mode only

The static memory layout may change over time to allow handling of bigger images as well. The level 2 restriction prolly will never get lifted, as it allows massive low level optimizations. Furthermore level 1 is discouraged since >30ys and can still be processed with the default decoder.

TODO:
- [ ] reconcile decoder interfaces
- [ ] move `SixelDecoder` to `DefaultDecoder`
- [ ] create "super decoder" probing for wasm with fallback to default
- [ ] more test cases
- [ ] set up gh actions as CI
- [ ] polish docs