### PR TITLE
Restore nearest behavior

### DIFF
--- a/src/SixelEncoder.ts
+++ b/src/SixelEncoder.ts
@@ -91,7 +91,7 @@ function processBand(
       // skip expensive color to palette matching if we have same color as before
       if (color !== oldColor) {
         oldColor = color;
-        idx = alpha(color) ? colorMap.get(color) || 0 : 0;
+        idx = alpha(color) ? colorMap.get(color) : 0;
         if (idx === undefined) {
           idx = nearestColorIndex(color, paletteRGB) + 1;
           colorMap.set(color, idx);


### PR DESCRIPTION
The nearest-matching palette behavior was removed in https://github.com/jerch/node-sixel/commit/b6b107cd1ce7fade04b6c90631eb852eb1e0eb36

This change puts it back.

I haven't managed to build it yet so I haven't tested it. I will do that next.